### PR TITLE
Add subscription details to subscription API

### DIFF
--- a/docs/onos/e2sub/subscription.md
+++ b/docs/onos/e2sub/subscription.md
@@ -4,6 +4,7 @@
 ## Table of Contents
 
 - [onos/e2sub/subscription/subscription.proto](#onos/e2sub/subscription/subscription.proto)
+    - [Action](#onos.e2sub.subscription.Action)
     - [AddSubscriptionRequest](#onos.e2sub.subscription.AddSubscriptionRequest)
     - [AddSubscriptionResponse](#onos.e2sub.subscription.AddSubscriptionResponse)
     - [Event](#onos.e2sub.subscription.Event)
@@ -12,17 +13,19 @@
     - [Lifecycle](#onos.e2sub.subscription.Lifecycle)
     - [ListSubscriptionsRequest](#onos.e2sub.subscription.ListSubscriptionsRequest)
     - [ListSubscriptionsResponse](#onos.e2sub.subscription.ListSubscriptionsResponse)
-    - [Payload](#onos.e2sub.subscription.Payload)
     - [RemoveSubscriptionRequest](#onos.e2sub.subscription.RemoveSubscriptionRequest)
     - [RemoveSubscriptionResponse](#onos.e2sub.subscription.RemoveSubscriptionResponse)
-    - [ServiceModel](#onos.e2sub.subscription.ServiceModel)
     - [Subscription](#onos.e2sub.subscription.Subscription)
+    - [SubscriptionDetails](#onos.e2sub.subscription.SubscriptionDetails)
+    - [SubsequentAction](#onos.e2sub.subscription.SubsequentAction)
     - [WatchSubscriptionsRequest](#onos.e2sub.subscription.WatchSubscriptionsRequest)
     - [WatchSubscriptionsResponse](#onos.e2sub.subscription.WatchSubscriptionsResponse)
   
-    - [Encoding](#onos.e2sub.subscription.Encoding)
+    - [ActionType](#onos.e2sub.subscription.ActionType)
     - [EventType](#onos.e2sub.subscription.EventType)
     - [Status](#onos.e2sub.subscription.Status)
+    - [SubsequentActionType](#onos.e2sub.subscription.SubsequentActionType)
+    - [TimeToWait](#onos.e2sub.subscription.TimeToWait)
   
     - [E2SubscriptionService](#onos.e2sub.subscription.E2SubscriptionService)
   
@@ -34,6 +37,24 @@
 <p align="right"><a href="#top">Top</a></p>
 
 ## onos/e2sub/subscription/subscription.proto
+
+
+
+<a name="onos.e2sub.subscription.Action"></a>
+
+### Action
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [int32](#int32) |  |  |
+| type | [ActionType](#onos.e2sub.subscription.ActionType) |  |  |
+| definition | [bytes](#bytes) |  |  |
+| subsequent_action | [SubsequentAction](#onos.e2sub.subscription.SubsequentAction) |  |  |
+
+
+
 
 
 
@@ -153,22 +174,6 @@ Lifecycle is the subscription lifecycle
 
 
 
-<a name="onos.e2sub.subscription.Payload"></a>
-
-### Payload
-Payload is a subscription payload
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| encoding | [Encoding](#onos.e2sub.subscription.Encoding) |  |  |
-| bytes | [bytes](#bytes) |  |  |
-
-
-
-
-
-
 <a name="onos.e2sub.subscription.RemoveSubscriptionRequest"></a>
 
 ### RemoveSubscriptionRequest
@@ -194,21 +199,6 @@ RemoveSubscriptionResponse a subscription delete response
 
 
 
-<a name="onos.e2sub.subscription.ServiceModel"></a>
-
-### ServiceModel
-ServiceModel is a service model definition
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| id | [string](#string) |  |  |
-
-
-
-
-
-
 <a name="onos.e2sub.subscription.Subscription"></a>
 
 ### Subscription
@@ -221,9 +211,40 @@ Subscription is a subscription state
 | revision | [uint64](#uint64) |  |  |
 | app_id | [string](#string) |  |  |
 | e2_node_id | [string](#string) |  |  |
-| service_model | [ServiceModel](#onos.e2sub.subscription.ServiceModel) |  |  |
-| payload | [Payload](#onos.e2sub.subscription.Payload) |  |  |
+| details | [SubscriptionDetails](#onos.e2sub.subscription.SubscriptionDetails) |  |  |
 | lifecycle | [Lifecycle](#onos.e2sub.subscription.Lifecycle) |  |  |
+
+
+
+
+
+
+<a name="onos.e2sub.subscription.SubscriptionDetails"></a>
+
+### SubscriptionDetails
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| event_trigger_definition | [bytes](#bytes) |  |  |
+| actions | [Action](#onos.e2sub.subscription.Action) | repeated |  |
+
+
+
+
+
+
+<a name="onos.e2sub.subscription.SubsequentAction"></a>
+
+### SubsequentAction
+sequence from e2ap-v01.00.00.asn1:1132
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| type | [SubsequentActionType](#onos.e2sub.subscription.SubsequentActionType) |  |  |
+| time_to_wait | [TimeToWait](#onos.e2sub.subscription.TimeToWait) |  |  |
 
 
 
@@ -262,15 +283,16 @@ Subscription is a subscription state
  
 
 
-<a name="onos.e2sub.subscription.Encoding"></a>
+<a name="onos.e2sub.subscription.ActionType"></a>
 
-### Encoding
-Encoding indicates a payload encoding
+### ActionType
+
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
-| ENCODING_ASN1 | 0 |  |
-| ENCODING_PROTO | 1 |  |
+| ACTION_TYPE_REPORT | 0 |  |
+| ACTION_TYPE_INSERT | 1 |  |
+| ACTION_TYPE_POLICY | 2 |  |
 
 
 
@@ -297,6 +319,46 @@ Status is a subscription status
 | ---- | ------ | ----------- |
 | ACTIVE | 0 |  |
 | PENDING_DELETE | 1 |  |
+
+
+
+<a name="onos.e2sub.subscription.SubsequentActionType"></a>
+
+### SubsequentActionType
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| SUBSEQUENT_ACTION_TYPE_CONTINUE | 0 |  |
+| SUBSEQUENT_ACTION_TYPE_WAIT | 1 |  |
+
+
+
+<a name="onos.e2sub.subscription.TimeToWait"></a>
+
+### TimeToWait
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| TIME_TO_WAIT_ZERO | 0 |  |
+| TIME_TO_WAIT_W1MS | 1 |  |
+| TIME_TO_WAIT_W2MS | 2 |  |
+| TIME_TO_WAIT_W5MS | 3 |  |
+| TIME_TO_WAIT_W10MS | 4 |  |
+| TIME_TO_WAIT_W20MS | 5 |  |
+| TIME_TO_WAIT_W30MS | 6 |  |
+| TIME_TO_WAIT_W40MS | 7 |  |
+| TIME_TO_WAIT_W50MS | 8 |  |
+| TIME_TO_WAIT_W100MS | 9 |  |
+| TIME_TO_WAIT_W200MS | 10 |  |
+| TIME_TO_WAIT_W500MS | 11 |  |
+| TIME_TO_WAIT_W1S | 12 |  |
+| TIME_TO_WAIT_W2S | 13 |  |
+| TIME_TO_WAIT_W5S | 14 |  |
+| TIME_TO_WAIT_W10S | 15 |  |
+| TIME_TO_WAIT_W20S | 16 |  |
+| TIME_TO_WAIT_W60S | 17 |  |
 
 
  

--- a/go/onos/e2sub/subscription/subscription.pb.go
+++ b/go/onos/e2sub/subscription/subscription.pb.go
@@ -87,30 +87,130 @@ func (EventType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_9092711340dfb78a, []int{1}
 }
 
-// Encoding indicates a payload encoding
-type Encoding int32
+type ActionType int32
 
 const (
-	Encoding_ENCODING_ASN1  Encoding = 0
-	Encoding_ENCODING_PROTO Encoding = 1
+	ActionType_ACTION_TYPE_REPORT ActionType = 0
+	ActionType_ACTION_TYPE_INSERT ActionType = 1
+	ActionType_ACTION_TYPE_POLICY ActionType = 2
 )
 
-var Encoding_name = map[int32]string{
-	0: "ENCODING_ASN1",
-	1: "ENCODING_PROTO",
+var ActionType_name = map[int32]string{
+	0: "ACTION_TYPE_REPORT",
+	1: "ACTION_TYPE_INSERT",
+	2: "ACTION_TYPE_POLICY",
 }
 
-var Encoding_value = map[string]int32{
-	"ENCODING_ASN1":  0,
-	"ENCODING_PROTO": 1,
+var ActionType_value = map[string]int32{
+	"ACTION_TYPE_REPORT": 0,
+	"ACTION_TYPE_INSERT": 1,
+	"ACTION_TYPE_POLICY": 2,
 }
 
-func (x Encoding) String() string {
-	return proto.EnumName(Encoding_name, int32(x))
+func (x ActionType) String() string {
+	return proto.EnumName(ActionType_name, int32(x))
 }
 
-func (Encoding) EnumDescriptor() ([]byte, []int) {
+func (ActionType) EnumDescriptor() ([]byte, []int) {
 	return fileDescriptor_9092711340dfb78a, []int{2}
+}
+
+type SubsequentActionType int32
+
+const (
+	SubsequentActionType_SUBSEQUENT_ACTION_TYPE_CONTINUE SubsequentActionType = 0
+	SubsequentActionType_SUBSEQUENT_ACTION_TYPE_WAIT     SubsequentActionType = 1
+)
+
+var SubsequentActionType_name = map[int32]string{
+	0: "SUBSEQUENT_ACTION_TYPE_CONTINUE",
+	1: "SUBSEQUENT_ACTION_TYPE_WAIT",
+}
+
+var SubsequentActionType_value = map[string]int32{
+	"SUBSEQUENT_ACTION_TYPE_CONTINUE": 0,
+	"SUBSEQUENT_ACTION_TYPE_WAIT":     1,
+}
+
+func (x SubsequentActionType) String() string {
+	return proto.EnumName(SubsequentActionType_name, int32(x))
+}
+
+func (SubsequentActionType) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_9092711340dfb78a, []int{3}
+}
+
+type TimeToWait int32
+
+const (
+	TimeToWait_TIME_TO_WAIT_ZERO   TimeToWait = 0
+	TimeToWait_TIME_TO_WAIT_W1MS   TimeToWait = 1
+	TimeToWait_TIME_TO_WAIT_W2MS   TimeToWait = 2
+	TimeToWait_TIME_TO_WAIT_W5MS   TimeToWait = 3
+	TimeToWait_TIME_TO_WAIT_W10MS  TimeToWait = 4
+	TimeToWait_TIME_TO_WAIT_W20MS  TimeToWait = 5
+	TimeToWait_TIME_TO_WAIT_W30MS  TimeToWait = 6
+	TimeToWait_TIME_TO_WAIT_W40MS  TimeToWait = 7
+	TimeToWait_TIME_TO_WAIT_W50MS  TimeToWait = 8
+	TimeToWait_TIME_TO_WAIT_W100MS TimeToWait = 9
+	TimeToWait_TIME_TO_WAIT_W200MS TimeToWait = 10
+	TimeToWait_TIME_TO_WAIT_W500MS TimeToWait = 11
+	TimeToWait_TIME_TO_WAIT_W1S    TimeToWait = 12
+	TimeToWait_TIME_TO_WAIT_W2S    TimeToWait = 13
+	TimeToWait_TIME_TO_WAIT_W5S    TimeToWait = 14
+	TimeToWait_TIME_TO_WAIT_W10S   TimeToWait = 15
+	TimeToWait_TIME_TO_WAIT_W20S   TimeToWait = 16
+	TimeToWait_TIME_TO_WAIT_W60S   TimeToWait = 17
+)
+
+var TimeToWait_name = map[int32]string{
+	0:  "TIME_TO_WAIT_ZERO",
+	1:  "TIME_TO_WAIT_W1MS",
+	2:  "TIME_TO_WAIT_W2MS",
+	3:  "TIME_TO_WAIT_W5MS",
+	4:  "TIME_TO_WAIT_W10MS",
+	5:  "TIME_TO_WAIT_W20MS",
+	6:  "TIME_TO_WAIT_W30MS",
+	7:  "TIME_TO_WAIT_W40MS",
+	8:  "TIME_TO_WAIT_W50MS",
+	9:  "TIME_TO_WAIT_W100MS",
+	10: "TIME_TO_WAIT_W200MS",
+	11: "TIME_TO_WAIT_W500MS",
+	12: "TIME_TO_WAIT_W1S",
+	13: "TIME_TO_WAIT_W2S",
+	14: "TIME_TO_WAIT_W5S",
+	15: "TIME_TO_WAIT_W10S",
+	16: "TIME_TO_WAIT_W20S",
+	17: "TIME_TO_WAIT_W60S",
+}
+
+var TimeToWait_value = map[string]int32{
+	"TIME_TO_WAIT_ZERO":   0,
+	"TIME_TO_WAIT_W1MS":   1,
+	"TIME_TO_WAIT_W2MS":   2,
+	"TIME_TO_WAIT_W5MS":   3,
+	"TIME_TO_WAIT_W10MS":  4,
+	"TIME_TO_WAIT_W20MS":  5,
+	"TIME_TO_WAIT_W30MS":  6,
+	"TIME_TO_WAIT_W40MS":  7,
+	"TIME_TO_WAIT_W50MS":  8,
+	"TIME_TO_WAIT_W100MS": 9,
+	"TIME_TO_WAIT_W200MS": 10,
+	"TIME_TO_WAIT_W500MS": 11,
+	"TIME_TO_WAIT_W1S":    12,
+	"TIME_TO_WAIT_W2S":    13,
+	"TIME_TO_WAIT_W5S":    14,
+	"TIME_TO_WAIT_W10S":   15,
+	"TIME_TO_WAIT_W20S":   16,
+	"TIME_TO_WAIT_W60S":   17,
+}
+
+func (x TimeToWait) String() string {
+	return proto.EnumName(TimeToWait_name, int32(x))
+}
+
+func (TimeToWait) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_9092711340dfb78a, []int{4}
 }
 
 // Lifecycle is the subscription lifecycle
@@ -211,120 +311,21 @@ func (m *Event) GetSubscription() Subscription {
 	return Subscription{}
 }
 
-// ServiceModel is a service model definition
-type ServiceModel struct {
-	ID ServiceModelID `protobuf:"bytes,4,opt,name=id,proto3,casttype=ServiceModelID" json:"id,omitempty"`
-}
-
-func (m *ServiceModel) Reset()         { *m = ServiceModel{} }
-func (m *ServiceModel) String() string { return proto.CompactTextString(m) }
-func (*ServiceModel) ProtoMessage()    {}
-func (*ServiceModel) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9092711340dfb78a, []int{2}
-}
-func (m *ServiceModel) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *ServiceModel) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	if deterministic {
-		return xxx_messageInfo_ServiceModel.Marshal(b, m, deterministic)
-	} else {
-		b = b[:cap(b)]
-		n, err := m.MarshalToSizedBuffer(b)
-		if err != nil {
-			return nil, err
-		}
-		return b[:n], nil
-	}
-}
-func (m *ServiceModel) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ServiceModel.Merge(m, src)
-}
-func (m *ServiceModel) XXX_Size() int {
-	return m.Size()
-}
-func (m *ServiceModel) XXX_DiscardUnknown() {
-	xxx_messageInfo_ServiceModel.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_ServiceModel proto.InternalMessageInfo
-
-func (m *ServiceModel) GetID() ServiceModelID {
-	if m != nil {
-		return m.ID
-	}
-	return ""
-}
-
-// Payload is a subscription payload
-type Payload struct {
-	Encoding Encoding `protobuf:"varint,1,opt,name=encoding,proto3,enum=onos.e2sub.subscription.Encoding" json:"encoding,omitempty"`
-	Bytes    []byte   `protobuf:"bytes,2,opt,name=bytes,proto3" json:"bytes,omitempty"`
-}
-
-func (m *Payload) Reset()         { *m = Payload{} }
-func (m *Payload) String() string { return proto.CompactTextString(m) }
-func (*Payload) ProtoMessage()    {}
-func (*Payload) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9092711340dfb78a, []int{3}
-}
-func (m *Payload) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *Payload) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	if deterministic {
-		return xxx_messageInfo_Payload.Marshal(b, m, deterministic)
-	} else {
-		b = b[:cap(b)]
-		n, err := m.MarshalToSizedBuffer(b)
-		if err != nil {
-			return nil, err
-		}
-		return b[:n], nil
-	}
-}
-func (m *Payload) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Payload.Merge(m, src)
-}
-func (m *Payload) XXX_Size() int {
-	return m.Size()
-}
-func (m *Payload) XXX_DiscardUnknown() {
-	xxx_messageInfo_Payload.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_Payload proto.InternalMessageInfo
-
-func (m *Payload) GetEncoding() Encoding {
-	if m != nil {
-		return m.Encoding
-	}
-	return Encoding_ENCODING_ASN1
-}
-
-func (m *Payload) GetBytes() []byte {
-	if m != nil {
-		return m.Bytes
-	}
-	return nil
-}
-
 // Subscription is a subscription state
 type Subscription struct {
-	ID           ID            `protobuf:"bytes,1,opt,name=id,proto3,casttype=ID" json:"id,omitempty"`
-	Revision     Revision      `protobuf:"varint,2,opt,name=revision,proto3,casttype=Revision" json:"revision,omitempty"`
-	AppID        AppID         `protobuf:"bytes,3,opt,name=app_id,json=appId,proto3,casttype=AppID" json:"app_id,omitempty"`
-	E2NodeID     E2NodeID      `protobuf:"bytes,4,opt,name=e2_node_id,json=e2NodeId,proto3,casttype=E2NodeID" json:"e2_node_id,omitempty"`
-	ServiceModel *ServiceModel `protobuf:"bytes,5,opt,name=service_model,json=serviceModel,proto3" json:"service_model,omitempty"`
-	Payload      *Payload      `protobuf:"bytes,6,opt,name=payload,proto3" json:"payload,omitempty"`
-	Lifecycle    Lifecycle     `protobuf:"bytes,7,opt,name=lifecycle,proto3" json:"lifecycle"`
+	ID        ID                   `protobuf:"bytes,1,opt,name=id,proto3,casttype=ID" json:"id,omitempty"`
+	Revision  Revision             `protobuf:"varint,2,opt,name=revision,proto3,casttype=Revision" json:"revision,omitempty"`
+	AppID     AppID                `protobuf:"bytes,3,opt,name=app_id,json=appId,proto3,casttype=AppID" json:"app_id,omitempty"`
+	E2NodeID  E2NodeID             `protobuf:"bytes,4,opt,name=e2_node_id,json=e2NodeId,proto3,casttype=E2NodeID" json:"e2_node_id,omitempty"`
+	Details   *SubscriptionDetails `protobuf:"bytes,5,opt,name=details,proto3" json:"details,omitempty"`
+	Lifecycle Lifecycle            `protobuf:"bytes,7,opt,name=lifecycle,proto3" json:"lifecycle"`
 }
 
 func (m *Subscription) Reset()         { *m = Subscription{} }
 func (m *Subscription) String() string { return proto.CompactTextString(m) }
 func (*Subscription) ProtoMessage()    {}
 func (*Subscription) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9092711340dfb78a, []int{4}
+	return fileDescriptor_9092711340dfb78a, []int{2}
 }
 func (m *Subscription) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -381,16 +382,9 @@ func (m *Subscription) GetE2NodeID() E2NodeID {
 	return ""
 }
 
-func (m *Subscription) GetServiceModel() *ServiceModel {
+func (m *Subscription) GetDetails() *SubscriptionDetails {
 	if m != nil {
-		return m.ServiceModel
-	}
-	return nil
-}
-
-func (m *Subscription) GetPayload() *Payload {
-	if m != nil {
-		return m.Payload
+		return m.Details
 	}
 	return nil
 }
@@ -402,6 +396,179 @@ func (m *Subscription) GetLifecycle() Lifecycle {
 	return Lifecycle{}
 }
 
+type SubscriptionDetails struct {
+	EventTriggerDefinition []byte    `protobuf:"bytes,1,opt,name=event_trigger_definition,json=eventTriggerDefinition,proto3" json:"event_trigger_definition,omitempty"`
+	Actions                []*Action `protobuf:"bytes,2,rep,name=actions,proto3" json:"actions,omitempty"`
+}
+
+func (m *SubscriptionDetails) Reset()         { *m = SubscriptionDetails{} }
+func (m *SubscriptionDetails) String() string { return proto.CompactTextString(m) }
+func (*SubscriptionDetails) ProtoMessage()    {}
+func (*SubscriptionDetails) Descriptor() ([]byte, []int) {
+	return fileDescriptor_9092711340dfb78a, []int{3}
+}
+func (m *SubscriptionDetails) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *SubscriptionDetails) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_SubscriptionDetails.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *SubscriptionDetails) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SubscriptionDetails.Merge(m, src)
+}
+func (m *SubscriptionDetails) XXX_Size() int {
+	return m.Size()
+}
+func (m *SubscriptionDetails) XXX_DiscardUnknown() {
+	xxx_messageInfo_SubscriptionDetails.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SubscriptionDetails proto.InternalMessageInfo
+
+func (m *SubscriptionDetails) GetEventTriggerDefinition() []byte {
+	if m != nil {
+		return m.EventTriggerDefinition
+	}
+	return nil
+}
+
+func (m *SubscriptionDetails) GetActions() []*Action {
+	if m != nil {
+		return m.Actions
+	}
+	return nil
+}
+
+type Action struct {
+	ID               int32             `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Type             ActionType        `protobuf:"varint,2,opt,name=type,proto3,enum=onos.e2sub.subscription.ActionType" json:"type,omitempty"`
+	Definition       []byte            `protobuf:"bytes,3,opt,name=definition,proto3" json:"definition,omitempty"`
+	SubsequentAction *SubsequentAction `protobuf:"bytes,4,opt,name=subsequent_action,json=subsequentAction,proto3" json:"subsequent_action,omitempty"`
+}
+
+func (m *Action) Reset()         { *m = Action{} }
+func (m *Action) String() string { return proto.CompactTextString(m) }
+func (*Action) ProtoMessage()    {}
+func (*Action) Descriptor() ([]byte, []int) {
+	return fileDescriptor_9092711340dfb78a, []int{4}
+}
+func (m *Action) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *Action) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_Action.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *Action) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Action.Merge(m, src)
+}
+func (m *Action) XXX_Size() int {
+	return m.Size()
+}
+func (m *Action) XXX_DiscardUnknown() {
+	xxx_messageInfo_Action.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Action proto.InternalMessageInfo
+
+func (m *Action) GetID() int32 {
+	if m != nil {
+		return m.ID
+	}
+	return 0
+}
+
+func (m *Action) GetType() ActionType {
+	if m != nil {
+		return m.Type
+	}
+	return ActionType_ACTION_TYPE_REPORT
+}
+
+func (m *Action) GetDefinition() []byte {
+	if m != nil {
+		return m.Definition
+	}
+	return nil
+}
+
+func (m *Action) GetSubsequentAction() *SubsequentAction {
+	if m != nil {
+		return m.SubsequentAction
+	}
+	return nil
+}
+
+// sequence from e2ap-v01.00.00.asn1:1132
+type SubsequentAction struct {
+	Type       SubsequentActionType `protobuf:"varint,1,opt,name=type,proto3,enum=onos.e2sub.subscription.SubsequentActionType" json:"type,omitempty"`
+	TimeToWait TimeToWait           `protobuf:"varint,2,opt,name=time_to_wait,json=timeToWait,proto3,enum=onos.e2sub.subscription.TimeToWait" json:"time_to_wait,omitempty"`
+}
+
+func (m *SubsequentAction) Reset()         { *m = SubsequentAction{} }
+func (m *SubsequentAction) String() string { return proto.CompactTextString(m) }
+func (*SubsequentAction) ProtoMessage()    {}
+func (*SubsequentAction) Descriptor() ([]byte, []int) {
+	return fileDescriptor_9092711340dfb78a, []int{5}
+}
+func (m *SubsequentAction) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *SubsequentAction) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_SubsequentAction.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *SubsequentAction) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SubsequentAction.Merge(m, src)
+}
+func (m *SubsequentAction) XXX_Size() int {
+	return m.Size()
+}
+func (m *SubsequentAction) XXX_DiscardUnknown() {
+	xxx_messageInfo_SubsequentAction.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SubsequentAction proto.InternalMessageInfo
+
+func (m *SubsequentAction) GetType() SubsequentActionType {
+	if m != nil {
+		return m.Type
+	}
+	return SubsequentActionType_SUBSEQUENT_ACTION_TYPE_CONTINUE
+}
+
+func (m *SubsequentAction) GetTimeToWait() TimeToWait {
+	if m != nil {
+		return m.TimeToWait
+	}
+	return TimeToWait_TIME_TO_WAIT_ZERO
+}
+
 // AddSubscriptionRequest a subscription request
 type AddSubscriptionRequest struct {
 	Subscription *Subscription `protobuf:"bytes,1,opt,name=subscription,proto3" json:"subscription,omitempty"`
@@ -411,7 +578,7 @@ func (m *AddSubscriptionRequest) Reset()         { *m = AddSubscriptionRequest{}
 func (m *AddSubscriptionRequest) String() string { return proto.CompactTextString(m) }
 func (*AddSubscriptionRequest) ProtoMessage()    {}
 func (*AddSubscriptionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9092711340dfb78a, []int{5}
+	return fileDescriptor_9092711340dfb78a, []int{6}
 }
 func (m *AddSubscriptionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -456,7 +623,7 @@ func (m *AddSubscriptionResponse) Reset()         { *m = AddSubscriptionResponse
 func (m *AddSubscriptionResponse) String() string { return proto.CompactTextString(m) }
 func (*AddSubscriptionResponse) ProtoMessage()    {}
 func (*AddSubscriptionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9092711340dfb78a, []int{6}
+	return fileDescriptor_9092711340dfb78a, []int{7}
 }
 func (m *AddSubscriptionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -501,7 +668,7 @@ func (m *RemoveSubscriptionRequest) Reset()         { *m = RemoveSubscriptionReq
 func (m *RemoveSubscriptionRequest) String() string { return proto.CompactTextString(m) }
 func (*RemoveSubscriptionRequest) ProtoMessage()    {}
 func (*RemoveSubscriptionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9092711340dfb78a, []int{7}
+	return fileDescriptor_9092711340dfb78a, []int{8}
 }
 func (m *RemoveSubscriptionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -545,7 +712,7 @@ func (m *RemoveSubscriptionResponse) Reset()         { *m = RemoveSubscriptionRe
 func (m *RemoveSubscriptionResponse) String() string { return proto.CompactTextString(m) }
 func (*RemoveSubscriptionResponse) ProtoMessage()    {}
 func (*RemoveSubscriptionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9092711340dfb78a, []int{8}
+	return fileDescriptor_9092711340dfb78a, []int{9}
 }
 func (m *RemoveSubscriptionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -582,7 +749,7 @@ func (m *GetSubscriptionRequest) Reset()         { *m = GetSubscriptionRequest{}
 func (m *GetSubscriptionRequest) String() string { return proto.CompactTextString(m) }
 func (*GetSubscriptionRequest) ProtoMessage()    {}
 func (*GetSubscriptionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9092711340dfb78a, []int{9}
+	return fileDescriptor_9092711340dfb78a, []int{10}
 }
 func (m *GetSubscriptionRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -626,7 +793,7 @@ func (m *GetSubscriptionResponse) Reset()         { *m = GetSubscriptionResponse
 func (m *GetSubscriptionResponse) String() string { return proto.CompactTextString(m) }
 func (*GetSubscriptionResponse) ProtoMessage()    {}
 func (*GetSubscriptionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9092711340dfb78a, []int{10}
+	return fileDescriptor_9092711340dfb78a, []int{11}
 }
 func (m *GetSubscriptionResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -669,7 +836,7 @@ func (m *ListSubscriptionsRequest) Reset()         { *m = ListSubscriptionsReque
 func (m *ListSubscriptionsRequest) String() string { return proto.CompactTextString(m) }
 func (*ListSubscriptionsRequest) ProtoMessage()    {}
 func (*ListSubscriptionsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9092711340dfb78a, []int{11}
+	return fileDescriptor_9092711340dfb78a, []int{12}
 }
 func (m *ListSubscriptionsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -706,7 +873,7 @@ func (m *ListSubscriptionsResponse) Reset()         { *m = ListSubscriptionsResp
 func (m *ListSubscriptionsResponse) String() string { return proto.CompactTextString(m) }
 func (*ListSubscriptionsResponse) ProtoMessage()    {}
 func (*ListSubscriptionsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9092711340dfb78a, []int{12}
+	return fileDescriptor_9092711340dfb78a, []int{13}
 }
 func (m *ListSubscriptionsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -750,7 +917,7 @@ func (m *WatchSubscriptionsRequest) Reset()         { *m = WatchSubscriptionsReq
 func (m *WatchSubscriptionsRequest) String() string { return proto.CompactTextString(m) }
 func (*WatchSubscriptionsRequest) ProtoMessage()    {}
 func (*WatchSubscriptionsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9092711340dfb78a, []int{13}
+	return fileDescriptor_9092711340dfb78a, []int{14}
 }
 func (m *WatchSubscriptionsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -794,7 +961,7 @@ func (m *WatchSubscriptionsResponse) Reset()         { *m = WatchSubscriptionsRe
 func (m *WatchSubscriptionsResponse) String() string { return proto.CompactTextString(m) }
 func (*WatchSubscriptionsResponse) ProtoMessage()    {}
 func (*WatchSubscriptionsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_9092711340dfb78a, []int{14}
+	return fileDescriptor_9092711340dfb78a, []int{15}
 }
 func (m *WatchSubscriptionsResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -833,12 +1000,15 @@ func (m *WatchSubscriptionsResponse) GetEvent() Event {
 func init() {
 	proto.RegisterEnum("onos.e2sub.subscription.Status", Status_name, Status_value)
 	proto.RegisterEnum("onos.e2sub.subscription.EventType", EventType_name, EventType_value)
-	proto.RegisterEnum("onos.e2sub.subscription.Encoding", Encoding_name, Encoding_value)
+	proto.RegisterEnum("onos.e2sub.subscription.ActionType", ActionType_name, ActionType_value)
+	proto.RegisterEnum("onos.e2sub.subscription.SubsequentActionType", SubsequentActionType_name, SubsequentActionType_value)
+	proto.RegisterEnum("onos.e2sub.subscription.TimeToWait", TimeToWait_name, TimeToWait_value)
 	proto.RegisterType((*Lifecycle)(nil), "onos.e2sub.subscription.Lifecycle")
 	proto.RegisterType((*Event)(nil), "onos.e2sub.subscription.Event")
-	proto.RegisterType((*ServiceModel)(nil), "onos.e2sub.subscription.ServiceModel")
-	proto.RegisterType((*Payload)(nil), "onos.e2sub.subscription.Payload")
 	proto.RegisterType((*Subscription)(nil), "onos.e2sub.subscription.Subscription")
+	proto.RegisterType((*SubscriptionDetails)(nil), "onos.e2sub.subscription.SubscriptionDetails")
+	proto.RegisterType((*Action)(nil), "onos.e2sub.subscription.Action")
+	proto.RegisterType((*SubsequentAction)(nil), "onos.e2sub.subscription.SubsequentAction")
 	proto.RegisterType((*AddSubscriptionRequest)(nil), "onos.e2sub.subscription.AddSubscriptionRequest")
 	proto.RegisterType((*AddSubscriptionResponse)(nil), "onos.e2sub.subscription.AddSubscriptionResponse")
 	proto.RegisterType((*RemoveSubscriptionRequest)(nil), "onos.e2sub.subscription.RemoveSubscriptionRequest")
@@ -856,59 +1026,76 @@ func init() {
 }
 
 var fileDescriptor_9092711340dfb78a = []byte{
-	// 821 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x56, 0x4f, 0x6f, 0xfa, 0x46,
-	0x10, 0xc5, 0xfc, 0x35, 0xf3, 0x23, 0xf9, 0x91, 0x55, 0x9a, 0x38, 0x56, 0x04, 0xd4, 0x52, 0x25,
-	0xca, 0x01, 0x12, 0x47, 0x4a, 0xda, 0x48, 0x3d, 0x40, 0xec, 0x46, 0x54, 0x09, 0xd0, 0x0d, 0x4d,
-	0x7b, 0x2a, 0x02, 0xbc, 0x4d, 0x2d, 0x11, 0xdb, 0xc5, 0x06, 0x89, 0x4a, 0x55, 0xcf, 0xbd, 0xe5,
-	0x63, 0xe5, 0x98, 0x63, 0x4f, 0xa8, 0x22, 0xdf, 0x22, 0x97, 0x56, 0xac, 0x17, 0xd7, 0x80, 0x4d,
-	0x8b, 0x94, 0xdb, 0xae, 0x77, 0xde, 0xdb, 0x37, 0xb3, 0xf3, 0x46, 0x86, 0x92, 0x69, 0x98, 0x76,
-	0x85, 0xc8, 0xf6, 0xa8, 0x57, 0xb1, 0x47, 0x3d, 0xbb, 0x3f, 0xd4, 0x2d, 0x47, 0x37, 0x8d, 0xa5,
-	0x4d, 0xd9, 0x1a, 0x9a, 0x8e, 0x89, 0x0e, 0xe7, 0xb1, 0x65, 0x1a, 0x5b, 0xf6, 0x1f, 0x8b, 0xfb,
-	0x0f, 0xe6, 0x83, 0x49, 0x63, 0x2a, 0xf3, 0x95, 0x1b, 0x2e, 0x29, 0x90, 0xbe, 0xd1, 0x7f, 0x22,
-	0xfd, 0x49, 0x7f, 0x40, 0xd0, 0x05, 0x24, 0x6d, 0xa7, 0xeb, 0x8c, 0x6c, 0x81, 0x2b, 0x70, 0xc5,
-	0x5d, 0x39, 0x5f, 0x0e, 0x21, 0x2b, 0xdf, 0xd1, 0x30, 0xcc, 0xc2, 0xa5, 0x27, 0x0e, 0x12, 0xea,
-	0x98, 0x18, 0x0e, 0x3a, 0x87, 0xb8, 0x33, 0xb1, 0x08, 0x23, 0x90, 0x42, 0x09, 0x68, 0x74, 0x7b,
-	0x62, 0x11, 0x4c, 0xe3, 0x51, 0x13, 0x32, 0xfe, 0x73, 0x21, 0x5a, 0xe0, 0x8a, 0x1f, 0xe4, 0xcf,
-	0xc2, 0x05, 0xf8, 0x36, 0xb5, 0xf8, 0xf3, 0x34, 0x1f, 0xc1, 0x4b, 0x04, 0xd2, 0x17, 0x90, 0xb9,
-	0x23, 0xc3, 0xb1, 0xde, 0x27, 0xb7, 0xa6, 0x46, 0x06, 0xa8, 0x08, 0x51, 0x5d, 0x13, 0xe2, 0x05,
-	0xae, 0x98, 0xae, 0x09, 0xb3, 0x69, 0x3e, 0x5a, 0x57, 0xde, 0xa6, 0xf9, 0x5d, 0x7f, 0x4c, 0x5d,
-	0xc1, 0x51, 0x5d, 0x93, 0x7e, 0x84, 0x54, 0xab, 0x3b, 0x19, 0x98, 0x5d, 0x0d, 0x7d, 0x05, 0x3c,
-	0x31, 0xfa, 0xa6, 0xa6, 0x1b, 0x0f, 0x2c, 0xa3, 0x4f, 0xc3, 0x33, 0x62, 0x81, 0xd8, 0x83, 0xa0,
-	0x7d, 0x48, 0xf4, 0x26, 0x0e, 0xb1, 0x69, 0x36, 0x19, 0xec, 0x6e, 0xa4, 0x3f, 0x62, 0x90, 0xf1,
-	0xcb, 0x47, 0xc7, 0x54, 0x1a, 0x47, 0xa5, 0x65, 0x3c, 0x69, 0x51, 0x57, 0x0e, 0x2a, 0x02, 0x3f,
-	0x24, 0x63, 0xdd, 0x5e, 0x54, 0x25, 0x5e, 0xcb, 0xbc, 0x4d, 0xf3, 0x3c, 0x66, 0xdf, 0xb0, 0x77,
-	0x8a, 0x3e, 0x87, 0x64, 0xd7, 0xb2, 0x3a, 0xba, 0x26, 0xc4, 0x28, 0x17, 0x9a, 0x4d, 0xf3, 0x89,
-	0xaa, 0x65, 0x51, 0x3a, 0x77, 0x81, 0x13, 0x5d, 0xcb, 0xaa, 0x6b, 0xe8, 0x1c, 0x80, 0xc8, 0x1d,
-	0xc3, 0xd4, 0x48, 0x67, 0xa9, 0x2a, 0xbc, 0x2a, 0x37, 0x4c, 0x8d, 0x50, 0x84, 0xb7, 0xc6, 0x3c,
-	0x71, 0x57, 0x1a, 0xfa, 0x06, 0x76, 0x6c, 0xb7, 0x62, 0x9d, 0xc7, 0x79, 0xc9, 0x84, 0xc4, 0x7f,
-	0xbd, 0x93, 0xaf, 0xbe, 0x38, 0x63, 0xfb, 0x5f, 0xe4, 0x12, 0x52, 0x96, 0x5b, 0x67, 0x21, 0x49,
-	0x59, 0x0a, 0xa1, 0x2c, 0xec, 0x3d, 0xf0, 0x02, 0x80, 0xbe, 0x86, 0xf4, 0x60, 0xd1, 0xb6, 0x42,
-	0x8a, 0xa2, 0xc3, 0x7b, 0xcd, 0x6b, 0x70, 0xd6, 0x28, 0xff, 0x42, 0xa5, 0x3e, 0x1c, 0x54, 0x35,
-	0xcd, 0xff, 0x1a, 0x98, 0xfc, 0x32, 0x22, 0xb6, 0x83, 0xea, 0x2b, 0x0d, 0xc9, 0x6d, 0xd1, 0x90,
-	0x2b, 0xad, 0xa8, 0xc1, 0xe1, 0xda, 0x25, 0xb6, 0x65, 0x1a, 0x36, 0x79, 0xcf, 0x5b, 0xbe, 0x84,
-	0x23, 0x4c, 0x1e, 0xcd, 0x31, 0x09, 0xca, 0x66, 0x63, 0x8b, 0x49, 0xc7, 0x20, 0x06, 0x41, 0x5d,
-	0x8d, 0xd2, 0x39, 0x1c, 0x5c, 0x13, 0x67, 0x7b, 0x56, 0x0d, 0x0e, 0xd7, 0x70, 0xef, 0x9f, 0xb6,
-	0x08, 0xc2, 0x8d, 0x6e, 0x2f, 0x5d, 0x63, 0x33, 0x7d, 0x92, 0x01, 0x47, 0x01, 0x67, 0x4c, 0xc3,
-	0xb7, 0xb0, 0xe3, 0x27, 0x9a, 0xcf, 0xbc, 0xd8, 0xb6, 0x23, 0x67, 0x99, 0x41, 0xba, 0x80, 0xa3,
-	0xef, 0xbb, 0x4e, 0xff, 0xe7, 0x20, 0x31, 0x48, 0x04, 0xde, 0x30, 0x87, 0xc4, 0x1a, 0x74, 0x27,
-	0x34, 0x5f, 0x1e, 0x7b, 0x7b, 0xe9, 0x07, 0x10, 0x83, 0x80, 0x4c, 0xe9, 0x25, 0x24, 0xc8, 0x7c,
-	0x5c, 0xb2, 0x32, 0xe5, 0x36, 0x0f, 0x55, 0x26, 0xcd, 0x85, 0x94, 0x8a, 0x90, 0x74, 0x67, 0x35,
-	0x02, 0x48, 0x56, 0xaf, 0xda, 0xf5, 0x7b, 0x35, 0x1b, 0x41, 0x08, 0x76, 0x5b, 0x6a, 0x43, 0xa9,
-	0x37, 0xae, 0x3b, 0x8a, 0x7a, 0xa3, 0xb6, 0xd5, 0x2c, 0x57, 0xba, 0x84, 0xb4, 0x37, 0x94, 0x11,
-	0x0f, 0xf1, 0x46, 0xb3, 0x31, 0x0f, 0x4d, 0x43, 0xa2, 0xaa, 0x28, 0xaa, 0x92, 0xe5, 0xd0, 0x07,
-	0x48, 0x7d, 0xd7, 0x52, 0xaa, 0x6d, 0x55, 0xc9, 0x46, 0xe7, 0x1b, 0xac, 0xde, 0x36, 0xef, 0x55,
-	0x25, 0x1b, 0x2b, 0x9d, 0x02, 0xbf, 0x18, 0x7f, 0x68, 0x0f, 0x76, 0xd4, 0xc6, 0x55, 0x93, 0x92,
-	0x57, 0xef, 0x1a, 0xa7, 0xee, 0x75, 0xde, 0xa7, 0x16, 0x6e, 0xb6, 0x9b, 0x59, 0x4e, 0xfe, 0x3b,
-	0x0e, 0x9f, 0xa8, 0xb2, 0x3f, 0x61, 0x36, 0x2a, 0x90, 0x03, 0x1f, 0x57, 0xec, 0x82, 0x2a, 0xa1,
-	0x29, 0x07, 0xbb, 0x57, 0x3c, 0xf9, 0xff, 0x00, 0x56, 0xe4, 0xdf, 0x00, 0xad, 0x7b, 0x00, 0xc9,
-	0xa1, 0x3c, 0xa1, 0x5e, 0x13, 0xcf, 0xb6, 0xc2, 0xb0, 0xeb, 0x1d, 0xf8, 0xb8, 0x62, 0x96, 0x0d,
-	0x49, 0x07, 0xdb, 0x71, 0x43, 0xd2, 0x61, 0x3e, 0xfc, 0x15, 0xf6, 0xd6, 0x0c, 0x82, 0x4e, 0x37,
-	0x0c, 0xd2, 0x60, 0xa3, 0x89, 0xf2, 0x36, 0x10, 0x76, 0xf7, 0xef, 0x80, 0xd6, 0x7b, 0x7e, 0x43,
-	0xc1, 0x43, 0x9d, 0xb5, 0xa1, 0xe0, 0xe1, 0xa6, 0x3a, 0xe1, 0x6a, 0xc2, 0xf3, 0x2c, 0xc7, 0xbd,
-	0xcc, 0x72, 0xdc, 0x5f, 0xb3, 0x1c, 0xf7, 0xf4, 0x9a, 0x8b, 0xbc, 0xbc, 0xe6, 0x22, 0x7f, 0xbe,
-	0xe6, 0x22, 0xbd, 0x24, 0xfd, 0x37, 0x3a, 0xfb, 0x27, 0x00, 0x00, 0xff, 0xff, 0x07, 0xbd, 0x5c,
-	0xd0, 0x78, 0x09, 0x00, 0x00,
+	// 1091 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x57, 0x5d, 0x4f, 0xdb, 0x56,
+	0x18, 0x8e, 0xf3, 0x45, 0xf2, 0x92, 0xc2, 0xe1, 0x94, 0x42, 0xc8, 0xaa, 0x04, 0xb9, 0x9a, 0x44,
+	0xa3, 0x0d, 0x52, 0x33, 0x60, 0xed, 0x5d, 0x82, 0xdd, 0x2a, 0x12, 0x71, 0xa8, 0x6d, 0x60, 0x9d,
+	0x26, 0x59, 0x21, 0x3e, 0x65, 0x96, 0x20, 0xf6, 0x62, 0xc3, 0xc4, 0xa4, 0x69, 0xf7, 0xbb, 0xea,
+	0x0f, 0xd8, 0xaf, 0xd8, 0xaf, 0xe8, 0xee, 0xba, 0xbb, 0x5d, 0xa1, 0x29, 0xfc, 0x8b, 0xde, 0x6c,
+	0x3a, 0xc7, 0x26, 0x18, 0x7f, 0xa4, 0x44, 0xea, 0x0d, 0x3a, 0x7e, 0xde, 0xe7, 0xfd, 0x3c, 0xe7,
+	0x3c, 0x87, 0x40, 0xdd, 0x1a, 0x58, 0xce, 0x06, 0x11, 0x9c, 0xf3, 0xe3, 0x0d, 0xe7, 0xfc, 0xd8,
+	0xe9, 0x0f, 0x4d, 0xdb, 0x35, 0xad, 0xc1, 0x9d, 0x8f, 0x75, 0x7b, 0x68, 0xb9, 0x16, 0x5e, 0xa6,
+	0xdc, 0x75, 0xc6, 0x5d, 0x0f, 0x9a, 0x2b, 0x8b, 0x27, 0xd6, 0x89, 0xc5, 0x38, 0x1b, 0x74, 0xe5,
+	0xd1, 0x79, 0x11, 0x8a, 0x7b, 0xe6, 0x5b, 0xd2, 0xbf, 0xec, 0x9f, 0x12, 0xbc, 0x03, 0x79, 0xc7,
+	0xed, 0xb9, 0xe7, 0x4e, 0x99, 0x5b, 0xe5, 0xd6, 0xe6, 0x84, 0xda, 0x7a, 0x42, 0xb0, 0x75, 0x95,
+	0xd1, 0x14, 0x9f, 0xce, 0xbf, 0xe3, 0x20, 0x27, 0x5d, 0x90, 0x81, 0x8b, 0xb7, 0x21, 0xeb, 0x5e,
+	0xda, 0xc4, 0x0f, 0xc0, 0x27, 0x06, 0x60, 0x6c, 0xed, 0xd2, 0x26, 0x0a, 0xe3, 0xe3, 0x2e, 0x94,
+	0x82, 0xf6, 0x72, 0x7a, 0x95, 0x5b, 0x9b, 0x15, 0xbe, 0x4c, 0x2e, 0x20, 0xf0, 0xd1, 0xca, 0xbe,
+	0xbf, 0xaa, 0xa5, 0x94, 0x3b, 0x01, 0xf8, 0xbf, 0xd2, 0x50, 0x0a, 0x92, 0xf0, 0x63, 0x48, 0x9b,
+	0x06, 0xab, 0xab, 0xd8, 0x2a, 0x8d, 0xae, 0x6a, 0xe9, 0xb6, 0xf8, 0x91, 0xfd, 0x55, 0xd2, 0xa6,
+	0x81, 0xd7, 0xa0, 0x30, 0x24, 0x17, 0xa6, 0x73, 0x93, 0x3b, 0xdb, 0x2a, 0x7d, 0xbc, 0xaa, 0x15,
+	0x14, 0x1f, 0x53, 0xc6, 0x56, 0xfc, 0x14, 0xf2, 0x3d, 0xdb, 0xd6, 0x4d, 0xa3, 0x9c, 0x61, 0xb1,
+	0xf0, 0xe8, 0xaa, 0x96, 0x6b, 0xda, 0x36, 0x0b, 0xe7, 0x2d, 0x94, 0x5c, 0xcf, 0xb6, 0xdb, 0x06,
+	0xde, 0x06, 0x20, 0x82, 0x3e, 0xb0, 0x0c, 0x42, 0xe9, 0x59, 0x46, 0x2f, 0x8f, 0xae, 0x6a, 0x05,
+	0x49, 0x90, 0x2d, 0x83, 0x30, 0x8f, 0xf1, 0x5a, 0x29, 0x10, 0x6f, 0x65, 0xe0, 0x97, 0x30, 0x63,
+	0x10, 0xb7, 0x67, 0x9e, 0x3a, 0xe5, 0x1c, 0x9b, 0xc3, 0x57, 0xf7, 0x9a, 0x83, 0xe8, 0xf9, 0x28,
+	0x37, 0xce, 0xf8, 0x25, 0x14, 0x4f, 0x6f, 0x36, 0xb7, 0x3c, 0xc3, 0x22, 0x25, 0xef, 0xc8, 0xf8,
+	0x18, 0xf8, 0xe3, 0xbc, 0x75, 0xe5, 0x7f, 0xe7, 0xe0, 0x61, 0x4c, 0x22, 0xfc, 0x2d, 0x94, 0x09,
+	0xdd, 0x47, 0xdd, 0x1d, 0x9a, 0x27, 0x27, 0x64, 0xa8, 0x1b, 0xe4, 0xad, 0x39, 0x30, 0xd9, 0x06,
+	0xd2, 0x41, 0x97, 0x94, 0x25, 0x66, 0xd7, 0x3c, 0xb3, 0x38, 0xb6, 0xe2, 0xe7, 0x30, 0xd3, 0xeb,
+	0xd3, 0x95, 0x53, 0x4e, 0xaf, 0x66, 0xd6, 0x66, 0x27, 0x1c, 0xb5, 0x26, 0xe3, 0x29, 0x37, 0x7c,
+	0xfe, 0x6f, 0x0e, 0xf2, 0x1e, 0x86, 0x97, 0xc6, 0x5b, 0x9a, 0x6b, 0xe5, 0x47, 0xb7, 0x9b, 0xb9,
+	0xe3, 0x1f, 0xc2, 0x34, 0x3b, 0x84, 0x4f, 0x3e, 0x11, 0x3a, 0x70, 0x0a, 0xab, 0x00, 0x81, 0x16,
+	0x32, 0xac, 0x85, 0x00, 0x82, 0x0f, 0x61, 0x81, 0x06, 0x20, 0x3f, 0x9d, 0xd3, 0xae, 0xbd, 0x8a,
+	0xd8, 0xbe, 0xce, 0x0a, 0x4f, 0x27, 0x6e, 0x91, 0xe7, 0xe1, 0xb7, 0x82, 0x9c, 0x10, 0xc2, 0xff,
+	0xc1, 0x01, 0x0a, 0xd3, 0x70, 0xf3, 0xce, 0x55, 0xfa, 0xfa, 0xde, 0xf1, 0x03, 0xfd, 0x48, 0x50,
+	0x72, 0xcd, 0x33, 0xa2, 0xbb, 0x96, 0xfe, 0x73, 0xcf, 0x74, 0x3f, 0x39, 0x10, 0xcd, 0x3c, 0x23,
+	0x9a, 0x75, 0xd4, 0x33, 0x5d, 0x05, 0xdc, 0xf1, 0x9a, 0xef, 0xc3, 0x52, 0xd3, 0x30, 0x82, 0x27,
+	0x40, 0xa1, 0x09, 0x1d, 0x17, 0xb7, 0x43, 0xd7, 0x96, 0x9b, 0xe2, 0xda, 0x86, 0x2e, 0xac, 0x01,
+	0xcb, 0x91, 0x24, 0x8e, 0x6d, 0x0d, 0x1c, 0xf2, 0x39, 0xb3, 0x3c, 0x87, 0x15, 0x85, 0x9c, 0x59,
+	0x17, 0x24, 0xae, 0x9b, 0x89, 0x12, 0xc1, 0x3f, 0x86, 0x4a, 0x9c, 0xab, 0x57, 0x23, 0xbf, 0x0d,
+	0x4b, 0xaf, 0x88, 0x3b, 0x7d, 0x54, 0x03, 0x96, 0x23, 0x7e, 0x9f, 0xbf, 0xed, 0x0a, 0x94, 0xf7,
+	0x4c, 0xe7, 0x4e, 0x1a, 0xc7, 0xaf, 0x8f, 0x1f, 0xc0, 0x4a, 0x8c, 0xcd, 0xaf, 0xe1, 0x35, 0x3c,
+	0x08, 0x06, 0xa2, 0x2f, 0x43, 0x66, 0x5a, 0x61, 0xbe, 0x1b, 0x81, 0xdf, 0x81, 0x95, 0xa3, 0x9e,
+	0xdb, 0xff, 0x31, 0xae, 0x18, 0x5c, 0x81, 0xc2, 0xc0, 0x1a, 0x12, 0xfb, 0xb4, 0x77, 0xc9, 0xfa,
+	0x2d, 0x28, 0xe3, 0x6f, 0xfe, 0x3b, 0xa8, 0xc4, 0x39, 0xfa, 0x95, 0xbe, 0x80, 0x1c, 0x13, 0x1b,
+	0x7f, 0x4c, 0xd5, 0xc9, 0x4f, 0x8f, 0x5f, 0x9a, 0xe7, 0x52, 0x5f, 0x83, 0xbc, 0xf7, 0xa2, 0x61,
+	0x80, 0x7c, 0x73, 0x57, 0x6b, 0x1f, 0x4a, 0x28, 0x85, 0x31, 0xcc, 0xed, 0x4b, 0xb2, 0xd8, 0x96,
+	0x5f, 0xe9, 0xa2, 0xb4, 0x27, 0x69, 0x12, 0xe2, 0xea, 0x2f, 0xa0, 0x38, 0x7e, 0xba, 0x70, 0x01,
+	0xb2, 0x72, 0x57, 0xa6, 0xd4, 0x22, 0xe4, 0x9a, 0xa2, 0x28, 0x89, 0x88, 0xc3, 0xb3, 0x30, 0x73,
+	0xb0, 0x2f, 0x36, 0x35, 0x49, 0x44, 0x69, 0xfa, 0xa1, 0x48, 0x9d, 0xee, 0xa1, 0x24, 0xa2, 0x4c,
+	0x5d, 0x03, 0xb8, 0xbd, 0xa1, 0x78, 0x09, 0x30, 0xcd, 0xd4, 0x95, 0x75, 0xed, 0xcd, 0xbe, 0xa4,
+	0x2b, 0xd2, 0x7e, 0x57, 0xd1, 0x50, 0x2a, 0x8c, 0xb7, 0x65, 0x55, 0x52, 0x34, 0xc4, 0x85, 0xf1,
+	0xfd, 0xee, 0x5e, 0x7b, 0xf7, 0x0d, 0x4a, 0xd7, 0x7f, 0x80, 0xc5, 0x38, 0x05, 0xc0, 0x4f, 0xa0,
+	0xa6, 0x1e, 0xb4, 0x54, 0xe9, 0xf5, 0x81, 0x24, 0x6b, 0x7a, 0xd0, 0x75, 0xb7, 0x2b, 0x6b, 0x6d,
+	0xf9, 0x80, 0xd6, 0x5d, 0x83, 0x2f, 0x12, 0x48, 0x47, 0xcd, 0xb6, 0x86, 0xb8, 0xfa, 0x9f, 0x19,
+	0x80, 0x5b, 0x55, 0xc0, 0x8f, 0x60, 0x41, 0x6b, 0x77, 0x24, 0x5d, 0xeb, 0x32, 0x82, 0xfe, 0xbd,
+	0xa4, 0x74, 0x51, 0x2a, 0x02, 0x1f, 0x3d, 0xeb, 0xa8, 0x88, 0x8b, 0xc2, 0x42, 0x47, 0x45, 0xe9,
+	0x28, 0xbc, 0xd5, 0x51, 0x51, 0x86, 0x36, 0x18, 0x0a, 0xd2, 0xe8, 0xa8, 0x28, 0x1b, 0xc5, 0x05,
+	0x8a, 0xe7, 0xa2, 0xf8, 0x26, 0xc5, 0xf3, 0x51, 0xfc, 0x1b, 0x8a, 0xcf, 0x44, 0xf1, 0x2d, 0x8a,
+	0x17, 0xf0, 0x32, 0x3c, 0x0c, 0xe7, 0xa5, 0x86, 0x62, 0xd4, 0x20, 0x30, 0x03, 0x44, 0x0d, 0x5b,
+	0xcc, 0x30, 0x8b, 0x17, 0x01, 0x85, 0x42, 0xa9, 0xa8, 0x14, 0x45, 0x05, 0x15, 0x3d, 0x88, 0xa2,
+	0x5b, 0x2a, 0x9a, 0x8b, 0x99, 0x64, 0x43, 0x45, 0xf3, 0x31, 0x93, 0x6c, 0xa8, 0x08, 0x45, 0xe1,
+	0xed, 0x86, 0x8a, 0x16, 0x84, 0xff, 0xb2, 0xf0, 0x48, 0x12, 0x82, 0xd7, 0x44, 0x25, 0xc3, 0x0b,
+	0xb3, 0x4f, 0xb0, 0x0b, 0xf3, 0x21, 0x91, 0xc5, 0x1b, 0xc9, 0xcf, 0x63, 0xac, 0xe6, 0x57, 0x1a,
+	0xf7, 0x77, 0xf0, 0xaf, 0xe6, 0xaf, 0x80, 0xa3, 0xca, 0x89, 0x85, 0xc4, 0x38, 0x89, 0x0a, 0x5d,
+	0xd9, 0x9c, 0xca, 0xc7, 0x4f, 0xef, 0xc2, 0x7c, 0x48, 0x62, 0x27, 0x34, 0x1d, 0x2f, 0xe2, 0x13,
+	0x9a, 0x4e, 0x52, 0xef, 0x5f, 0x60, 0x21, 0x22, 0xab, 0xf8, 0xd9, 0x84, 0x7f, 0xbf, 0xe2, 0xe5,
+	0xb9, 0x22, 0x4c, 0xe3, 0xe2, 0xe7, 0xfe, 0x0d, 0x70, 0x54, 0x29, 0x27, 0x0c, 0x3c, 0x51, 0x8f,
+	0x27, 0x0c, 0x3c, 0x59, 0x8a, 0x1b, 0x5c, 0xab, 0xfc, 0x7e, 0x54, 0xe5, 0x3e, 0x8c, 0xaa, 0xdc,
+	0xbf, 0xa3, 0x2a, 0xf7, 0xee, 0xba, 0x9a, 0xfa, 0x70, 0x5d, 0x4d, 0xfd, 0x73, 0x5d, 0x4d, 0x1d,
+	0xe7, 0xd9, 0xef, 0x8e, 0xcd, 0xff, 0x03, 0x00, 0x00, 0xff, 0xff, 0xee, 0x45, 0x85, 0x8b, 0xd4,
+	0x0c, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1239,71 +1426,6 @@ func (m *Event) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *ServiceModel) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalToSizedBuffer(dAtA[:size])
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *ServiceModel) MarshalTo(dAtA []byte) (int, error) {
-	size := m.Size()
-	return m.MarshalToSizedBuffer(dAtA[:size])
-}
-
-func (m *ServiceModel) MarshalToSizedBuffer(dAtA []byte) (int, error) {
-	i := len(dAtA)
-	_ = i
-	var l int
-	_ = l
-	if len(m.ID) > 0 {
-		i -= len(m.ID)
-		copy(dAtA[i:], m.ID)
-		i = encodeVarintSubscription(dAtA, i, uint64(len(m.ID)))
-		i--
-		dAtA[i] = 0x22
-	}
-	return len(dAtA) - i, nil
-}
-
-func (m *Payload) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalToSizedBuffer(dAtA[:size])
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *Payload) MarshalTo(dAtA []byte) (int, error) {
-	size := m.Size()
-	return m.MarshalToSizedBuffer(dAtA[:size])
-}
-
-func (m *Payload) MarshalToSizedBuffer(dAtA []byte) (int, error) {
-	i := len(dAtA)
-	_ = i
-	var l int
-	_ = l
-	if len(m.Bytes) > 0 {
-		i -= len(m.Bytes)
-		copy(dAtA[i:], m.Bytes)
-		i = encodeVarintSubscription(dAtA, i, uint64(len(m.Bytes)))
-		i--
-		dAtA[i] = 0x12
-	}
-	if m.Encoding != 0 {
-		i = encodeVarintSubscription(dAtA, i, uint64(m.Encoding))
-		i--
-		dAtA[i] = 0x8
-	}
-	return len(dAtA) - i, nil
-}
-
 func (m *Subscription) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -1334,21 +1456,9 @@ func (m *Subscription) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	i--
 	dAtA[i] = 0x3a
-	if m.Payload != nil {
+	if m.Details != nil {
 		{
-			size, err := m.Payload.MarshalToSizedBuffer(dAtA[:i])
-			if err != nil {
-				return 0, err
-			}
-			i -= size
-			i = encodeVarintSubscription(dAtA, i, uint64(size))
-		}
-		i--
-		dAtA[i] = 0x32
-	}
-	if m.ServiceModel != nil {
-		{
-			size, err := m.ServiceModel.MarshalToSizedBuffer(dAtA[:i])
+			size, err := m.Details.MarshalToSizedBuffer(dAtA[:i])
 			if err != nil {
 				return 0, err
 			}
@@ -1383,6 +1493,135 @@ func (m *Subscription) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i = encodeVarintSubscription(dAtA, i, uint64(len(m.ID)))
 		i--
 		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *SubscriptionDetails) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SubscriptionDetails) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SubscriptionDetails) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Actions) > 0 {
+		for iNdEx := len(m.Actions) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Actions[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintSubscription(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x12
+		}
+	}
+	if len(m.EventTriggerDefinition) > 0 {
+		i -= len(m.EventTriggerDefinition)
+		copy(dAtA[i:], m.EventTriggerDefinition)
+		i = encodeVarintSubscription(dAtA, i, uint64(len(m.EventTriggerDefinition)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *Action) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *Action) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Action) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.SubsequentAction != nil {
+		{
+			size, err := m.SubsequentAction.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintSubscription(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0x22
+	}
+	if len(m.Definition) > 0 {
+		i -= len(m.Definition)
+		copy(dAtA[i:], m.Definition)
+		i = encodeVarintSubscription(dAtA, i, uint64(len(m.Definition)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.Type != 0 {
+		i = encodeVarintSubscription(dAtA, i, uint64(m.Type))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.ID != 0 {
+		i = encodeVarintSubscription(dAtA, i, uint64(m.ID))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *SubsequentAction) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *SubsequentAction) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *SubsequentAction) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.TimeToWait != 0 {
+		i = encodeVarintSubscription(dAtA, i, uint64(m.TimeToWait))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.Type != 0 {
+		i = encodeVarintSubscription(dAtA, i, uint64(m.Type))
+		i--
+		dAtA[i] = 0x8
 	}
 	return len(dAtA) - i, nil
 }
@@ -1738,35 +1977,6 @@ func (m *Event) Size() (n int) {
 	return n
 }
 
-func (m *ServiceModel) Size() (n int) {
-	if m == nil {
-		return 0
-	}
-	var l int
-	_ = l
-	l = len(m.ID)
-	if l > 0 {
-		n += 1 + l + sovSubscription(uint64(l))
-	}
-	return n
-}
-
-func (m *Payload) Size() (n int) {
-	if m == nil {
-		return 0
-	}
-	var l int
-	_ = l
-	if m.Encoding != 0 {
-		n += 1 + sovSubscription(uint64(m.Encoding))
-	}
-	l = len(m.Bytes)
-	if l > 0 {
-		n += 1 + l + sovSubscription(uint64(l))
-	}
-	return n
-}
-
 func (m *Subscription) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1788,16 +1998,69 @@ func (m *Subscription) Size() (n int) {
 	if l > 0 {
 		n += 1 + l + sovSubscription(uint64(l))
 	}
-	if m.ServiceModel != nil {
-		l = m.ServiceModel.Size()
-		n += 1 + l + sovSubscription(uint64(l))
-	}
-	if m.Payload != nil {
-		l = m.Payload.Size()
+	if m.Details != nil {
+		l = m.Details.Size()
 		n += 1 + l + sovSubscription(uint64(l))
 	}
 	l = m.Lifecycle.Size()
 	n += 1 + l + sovSubscription(uint64(l))
+	return n
+}
+
+func (m *SubscriptionDetails) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.EventTriggerDefinition)
+	if l > 0 {
+		n += 1 + l + sovSubscription(uint64(l))
+	}
+	if len(m.Actions) > 0 {
+		for _, e := range m.Actions {
+			l = e.Size()
+			n += 1 + l + sovSubscription(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *Action) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.ID != 0 {
+		n += 1 + sovSubscription(uint64(m.ID))
+	}
+	if m.Type != 0 {
+		n += 1 + sovSubscription(uint64(m.Type))
+	}
+	l = len(m.Definition)
+	if l > 0 {
+		n += 1 + l + sovSubscription(uint64(l))
+	}
+	if m.SubsequentAction != nil {
+		l = m.SubsequentAction.Size()
+		n += 1 + l + sovSubscription(uint64(l))
+	}
+	return n
+}
+
+func (m *SubsequentAction) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Type != 0 {
+		n += 1 + sovSubscription(uint64(m.Type))
+	}
+	if m.TimeToWait != 0 {
+		n += 1 + sovSubscription(uint64(m.TimeToWait))
+	}
 	return n
 }
 
@@ -2105,197 +2368,6 @@ func (m *Event) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *ServiceModel) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowSubscription
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: ServiceModel: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: ServiceModel: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 4:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ID", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowSubscription
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthSubscription
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return ErrInvalidLengthSubscription
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.ID = ServiceModelID(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipSubscription(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthSubscription
-			}
-			if (iNdEx + skippy) < 0 {
-				return ErrInvalidLengthSubscription
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *Payload) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowSubscription
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: Payload: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: Payload: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Encoding", wireType)
-			}
-			m.Encoding = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowSubscription
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.Encoding |= Encoding(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Bytes", wireType)
-			}
-			var byteLen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowSubscription
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				byteLen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if byteLen < 0 {
-				return ErrInvalidLengthSubscription
-			}
-			postIndex := iNdEx + byteLen
-			if postIndex < 0 {
-				return ErrInvalidLengthSubscription
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Bytes = append(m.Bytes[:0], dAtA[iNdEx:postIndex]...)
-			if m.Bytes == nil {
-				m.Bytes = []byte{}
-			}
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipSubscription(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if skippy < 0 {
-				return ErrInvalidLengthSubscription
-			}
-			if (iNdEx + skippy) < 0 {
-				return ErrInvalidLengthSubscription
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
 func (m *Subscription) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2442,7 +2514,7 @@ func (m *Subscription) Unmarshal(dAtA []byte) error {
 			iNdEx = postIndex
 		case 5:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ServiceModel", wireType)
+				return fmt.Errorf("proto: wrong wireType = %d for field Details", wireType)
 			}
 			var msglen int
 			for shift := uint(0); ; shift += 7 {
@@ -2469,46 +2541,10 @@ func (m *Subscription) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
-			if m.ServiceModel == nil {
-				m.ServiceModel = &ServiceModel{}
+			if m.Details == nil {
+				m.Details = &SubscriptionDetails{}
 			}
-			if err := m.ServiceModel.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		case 6:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Payload", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowSubscription
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthSubscription
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthSubscription
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if m.Payload == nil {
-				m.Payload = &Payload{}
-			}
-			if err := m.Payload.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+			if err := m.Details.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -2545,6 +2581,379 @@ func (m *Subscription) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipSubscription(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthSubscription
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthSubscription
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SubscriptionDetails) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowSubscription
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SubscriptionDetails: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SubscriptionDetails: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field EventTriggerDefinition", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSubscription
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthSubscription
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthSubscription
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.EventTriggerDefinition = append(m.EventTriggerDefinition[:0], dAtA[iNdEx:postIndex]...)
+			if m.EventTriggerDefinition == nil {
+				m.EventTriggerDefinition = []byte{}
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Actions", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSubscription
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthSubscription
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthSubscription
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Actions = append(m.Actions, &Action{})
+			if err := m.Actions[len(m.Actions)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipSubscription(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthSubscription
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthSubscription
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *Action) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowSubscription
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: Action: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: Action: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ID", wireType)
+			}
+			m.ID = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSubscription
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.ID |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			m.Type = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSubscription
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Type |= ActionType(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Definition", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSubscription
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthSubscription
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthSubscription
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Definition = append(m.Definition[:0], dAtA[iNdEx:postIndex]...)
+			if m.Definition == nil {
+				m.Definition = []byte{}
+			}
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SubsequentAction", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSubscription
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthSubscription
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthSubscription
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.SubsequentAction == nil {
+				m.SubsequentAction = &SubsequentAction{}
+			}
+			if err := m.SubsequentAction.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipSubscription(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthSubscription
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthSubscription
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SubsequentAction) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowSubscription
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SubsequentAction: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SubsequentAction: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Type", wireType)
+			}
+			m.Type = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSubscription
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Type |= SubsequentActionType(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field TimeToWait", wireType)
+			}
+			m.TimeToWait = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowSubscription
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.TimeToWait |= TimeToWait(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipSubscription(dAtA[iNdEx:])

--- a/proto/onos/e2sub/subscription/subscription.proto
+++ b/proto/onos/e2sub/subscription/subscription.proto
@@ -64,32 +64,64 @@ message Event {
     Subscription subscription = 2 [(gogoproto.nullable) = false];
 }
 
-// Encoding indicates a payload encoding
-enum Encoding {
-    ENCODING_ASN1 = 0;
-    ENCODING_PROTO = 1;
-}
-
-// ServiceModel is a service model definition
-message ServiceModel {
-    string id = 4 [(gogoproto.casttype) = "ServiceModelID", (gogoproto.customname) = "ID"];
-}
-
-// Payload is a subscription payload
-message Payload {
-    Encoding encoding = 1;
-    bytes bytes = 2;
-}
-
 // Subscription is a subscription state
 message Subscription {
     string id = 1 [(gogoproto.casttype) = "ID", (gogoproto.customname) = "ID"];
     uint64 revision = 2 [(gogoproto.casttype) = "Revision"];
     string app_id = 3 [(gogoproto.casttype) = "AppID", (gogoproto.customname) = "AppID"];
     string e2_node_id = 4 [(gogoproto.casttype) = "E2NodeID", (gogoproto.customname) = "E2NodeID"];
-    ServiceModel service_model = 5;
-    Payload payload = 6;
+    SubscriptionDetails details = 5;
     Lifecycle lifecycle = 7 [(gogoproto.nullable) = false];
+}
+
+message SubscriptionDetails {
+    bytes event_trigger_definition = 1;
+    repeated Action actions = 2;
+}
+
+message Action {
+    int32 id = 1 [(gogoproto.customname) = "ID"];
+    ActionType type = 2;
+    bytes definition = 3;
+    SubsequentAction subsequent_action = 4;
+}
+
+enum ActionType {
+    ACTION_TYPE_REPORT = 0;
+    ACTION_TYPE_INSERT = 1;
+    ACTION_TYPE_POLICY = 2;
+}
+
+// sequence from e2ap-v01.00.00.asn1:1132
+message SubsequentAction {
+    SubsequentActionType type = 1;
+    TimeToWait time_to_wait = 2;
+}
+
+enum SubsequentActionType {
+    SUBSEQUENT_ACTION_TYPE_CONTINUE = 0;
+    SUBSEQUENT_ACTION_TYPE_WAIT = 1;
+}
+
+enum TimeToWait {
+    TIME_TO_WAIT_ZERO = 0;
+    TIME_TO_WAIT_W1MS = 1;
+    TIME_TO_WAIT_W2MS = 2;
+    TIME_TO_WAIT_W5MS = 3;
+    TIME_TO_WAIT_W10MS = 4;
+    TIME_TO_WAIT_W20MS = 5;
+    TIME_TO_WAIT_W30MS = 6;
+    TIME_TO_WAIT_W40MS = 7;
+    TIME_TO_WAIT_W50MS = 8;
+    TIME_TO_WAIT_W100MS = 9;
+    TIME_TO_WAIT_W200MS = 10;
+    TIME_TO_WAIT_W500MS = 11;
+    TIME_TO_WAIT_W1S = 12;
+    TIME_TO_WAIT_W2S = 13;
+    TIME_TO_WAIT_W5S = 14;
+    TIME_TO_WAIT_W10S = 15;
+    TIME_TO_WAIT_W20S = 16;
+    TIME_TO_WAIT_W60S = 17;
 }
 
 // AddSubscriptionRequest a subscription request

--- a/python/onos/e2sub/subscription.py
+++ b/python/onos/e2sub/subscription.py
@@ -24,11 +24,36 @@ class EventType(betterproto.Enum):
     REMOVED = 3
 
 
-class Encoding(betterproto.Enum):
-    """Encoding indicates a payload encoding"""
+class ActionType(betterproto.Enum):
+    ACTION_TYPE_REPORT = 0
+    ACTION_TYPE_INSERT = 1
+    ACTION_TYPE_POLICY = 2
 
-    ENCODING_ASN1 = 0
-    ENCODING_PROTO = 1
+
+class SubsequentActionType(betterproto.Enum):
+    SUBSEQUENT_ACTION_TYPE_CONTINUE = 0
+    SUBSEQUENT_ACTION_TYPE_WAIT = 1
+
+
+class TimeToWait(betterproto.Enum):
+    TIME_TO_WAIT_ZERO = 0
+    TIME_TO_WAIT_W1MS = 1
+    TIME_TO_WAIT_W2MS = 2
+    TIME_TO_WAIT_W5MS = 3
+    TIME_TO_WAIT_W10MS = 4
+    TIME_TO_WAIT_W20MS = 5
+    TIME_TO_WAIT_W30MS = 6
+    TIME_TO_WAIT_W40MS = 7
+    TIME_TO_WAIT_W50MS = 8
+    TIME_TO_WAIT_W100MS = 9
+    TIME_TO_WAIT_W200MS = 10
+    TIME_TO_WAIT_W500MS = 11
+    TIME_TO_WAIT_W1S = 12
+    TIME_TO_WAIT_W2S = 13
+    TIME_TO_WAIT_W5S = 14
+    TIME_TO_WAIT_W10S = 15
+    TIME_TO_WAIT_W20S = 16
+    TIME_TO_WAIT_W60S = 17
 
 
 @dataclass(eq=False, repr=False)
@@ -53,27 +78,6 @@ class Event(betterproto.Message):
 
 
 @dataclass(eq=False, repr=False)
-class ServiceModel(betterproto.Message):
-    """ServiceModel is a service model definition"""
-
-    id: str = betterproto.string_field(4)
-
-    def __post_init__(self) -> None:
-        super().__post_init__()
-
-
-@dataclass(eq=False, repr=False)
-class Payload(betterproto.Message):
-    """Payload is a subscription payload"""
-
-    encoding: "Encoding" = betterproto.enum_field(1)
-    bytes: bytes = betterproto.bytes_field(2)
-
-    def __post_init__(self) -> None:
-        super().__post_init__()
-
-
-@dataclass(eq=False, repr=False)
 class Subscription(betterproto.Message):
     """Subscription is a subscription state"""
 
@@ -81,9 +85,39 @@ class Subscription(betterproto.Message):
     revision: int = betterproto.uint64_field(2)
     app_id: str = betterproto.string_field(3)
     e2_node_id: str = betterproto.string_field(4)
-    service_model: "ServiceModel" = betterproto.message_field(5)
-    payload: "Payload" = betterproto.message_field(6)
+    details: "SubscriptionDetails" = betterproto.message_field(5)
     lifecycle: "Lifecycle" = betterproto.message_field(7)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+
+
+@dataclass(eq=False, repr=False)
+class SubscriptionDetails(betterproto.Message):
+    event_trigger_definition: bytes = betterproto.bytes_field(1)
+    actions: List["Action"] = betterproto.message_field(2)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+
+
+@dataclass(eq=False, repr=False)
+class Action(betterproto.Message):
+    id: int = betterproto.int32_field(1)
+    type: "ActionType" = betterproto.enum_field(2)
+    definition: bytes = betterproto.bytes_field(3)
+    subsequent_action: "SubsequentAction" = betterproto.message_field(4)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+
+
+@dataclass(eq=False, repr=False)
+class SubsequentAction(betterproto.Message):
+    """sequence from e2ap-v01.00.00.asn1:1132"""
+
+    type: "SubsequentActionType" = betterproto.enum_field(1)
+    time_to_wait: "TimeToWait" = betterproto.enum_field(2)
 
     def __post_init__(self) -> None:
         super().__post_init__()


### PR DESCRIPTION
This PR replaces the `Subscription` payload in the onos-e2sub NB API with a `SubscriptioDetails` message. The `SubscriptionDetails` message is similar to the structure of the E2AP subscription details, but with redundant (AFAICT) fields (like IE metadata) removed, and with naming more consistent with the public API.

This message structure should still be hidden from application code, perhaps exposing instead a builder for subscription requests.