### PR TITLE
config Go: for int and uint the bit width must be added in TypedValues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ deps: # @HELP ensure that the required dependencies are in place
 	bash -c "diff -u <(echo -n) <(git diff go.sum)"
 
 linters: # @HELP examines Go source code and reports coding problems
-	golangci-lint run
+	cd go && golangci-lint run
 
 license_check: # @HELP examine and ensure license headers exist
 	@if [ ! -d "../build-tools" ]; then cd .. && git clone https://github.com/onosproject/build-tools.git; fi

--- a/go/onos/config/change/device/typedvalue_test.go
+++ b/go/onos/config/change/device/typedvalue_test.go
@@ -16,33 +16,35 @@ package device
 
 import (
 	"encoding/base64"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"gotest.tools/assert"
+	"math/big"
 	"testing"
 )
 
 const testString = "This is a test"
 const (
-	testNegativeInt = -9223372036854775808
-	testZeroInt     = 0
-	testPositiveInt = 9223372036854775807
+	testNegativeInt64 = -9223372036854775808
+	testNegativeInt32 = -2147483648
+	testZeroInt       = 0
+	testPositiveInt32 = 2147483647
+	testPositiveInt64 = 9223372036854775807
 )
 const (
-	testZeroUint   = uint(0)
-	testElevenUint = uint(11)
-	testMaxUint    = uint(18446744073709551615)
+	testZeroUint   = 0
+	testElevenUint = 11
+	testMaxUint    = uint64(18446744073709551615)
 )
 const (
-	testPrecision3 = 3
-	testPrecision6 = 6
-	testDigitsZero = 0
-	testPrecision0 = 0
+	testPrecision3 = uint8(3)
+	testPrecision6 = uint8(6)
+	testDigitsZero = uint8(0)
+	testPrecision0 = uint8(0)
 )
 const (
-	testFloatNeg = float32(-3.4E+38)
-	testFloatPos = float32(3.4E+38)
+	testFloatNeg = -3.4E+38
+	testFloatPos = 3.4E+38
 )
 const (
 	testStringBytes    = "onos rocks!"
@@ -51,13 +53,13 @@ const (
 
 var testLeafListString = []string{"abc", "def", "ghi", "with,comma"}
 
-var testLeafListInt = []int{testNegativeInt, testZeroInt, testPositiveInt}
+var testLeafListInt = []int64{testNegativeInt64, testZeroInt, testPositiveInt64}
 
-var testLeafListUint = []uint{testZeroUint, testElevenUint, testMaxUint}
+var testLeafListUint = []uint64{testZeroUint, testElevenUint, testMaxUint}
 
 var testLeafListBool = []bool{true, false, false, true}
 
-var testLeafListDecimal = []int64{testNegativeInt, testZeroInt, testPositiveInt}
+var testLeafListDecimal = []int64{testNegativeInt32, testZeroInt, testPositiveInt32}
 
 var testLeafListFloat = []float32{testFloatNeg, testZeroInt, testFloatPos}
 
@@ -73,7 +75,7 @@ func Test_TypedValueEmpty(t *testing.T) {
 	testConversion(t, tv)
 	assert.Equal(t, tv.ValueToString(), "")
 
-	tv2, err := NewTypedValue([]byte{0x0, 0x0, 0x0}, ValueType_EMPTY, []int32{})
+	tv2, err := NewTypedValue([]byte{0x0, 0x0, 0x0}, ValueType_EMPTY, []uint8{})
 	assert.NilError(t, err)
 	assert.Equal(t, tv2.String(), "")
 	assert.Equal(t, tv2.ValueToString(), "")
@@ -88,39 +90,40 @@ func Test_TypedValueString(t *testing.T) {
 }
 
 func Test_TypedValueInt(t *testing.T) {
-	tv := NewInt64(testNegativeInt)
-	assert.Equal(t, tv.String(), fmt.Sprintf("%d", testNegativeInt))
+	tv := newInt64(big.NewInt(testNegativeInt64), 64)
+	assert.Equal(t, tv.String(), fmt.Sprintf("%d", testNegativeInt64))
 	assert.Equal(t, len(tv.Bytes), 8)
-	assert.DeepEqual(t, tv.Bytes, []uint8{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x80})
+	assert.DeepEqual(t, tv.Bytes, []uint8{0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
 
 	testConversion(t, (*TypedValue)(tv))
 
-	tv = NewInt64(12345678)
+	tv = newInt64(big.NewInt(12345678), 32)
 	assert.Equal(t, tv.String(), fmt.Sprintf("%d", 12345678))
-	assert.DeepEqual(t, tv.Bytes, []uint8{0x4E, 0x61, 0xBC, 0x0, 0x0, 0x0, 0x0, 0x0})
+	assert.DeepEqual(t, tv.Bytes, []uint8{0xbc, 0x61, 0x4e})
 
-	tv = NewInt64(testPositiveInt)
-	assert.Equal(t, tv.String(), fmt.Sprintf("%d", testPositiveInt))
-	assert.DeepEqual(t, tv.Bytes, []uint8{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F})
+	tv = newInt64(big.NewInt(testPositiveInt64), 64)
+	assert.Equal(t, tv.String(), fmt.Sprintf("%d", testPositiveInt64))
+	assert.DeepEqual(t, tv.Bytes, []uint8{0x7f, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
 
-	tv = NewInt64(testZeroInt)
+	tv = newInt64(big.NewInt(testZeroInt), 32)
 	assert.Equal(t, tv.String(), fmt.Sprintf("%d", testZeroInt))
 	assert.Equal(t, (*TypedValue)(tv).ValueToString(), "0")
-	assert.DeepEqual(t, tv.Bytes, []uint8{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
+	assert.DeepEqual(t, tv.Bytes, []uint8{})
 }
 
 func Test_TypedValueUint(t *testing.T) {
-	tv := NewUint64(testZeroUint)
+	tv := newUint64(big.NewInt(testZeroUint), 8)
 	assert.Equal(t, tv.String(), fmt.Sprintf("%d", testZeroUint))
-	assert.Equal(t, len(tv.Bytes), 8)
-	assert.DeepEqual(t, tv.Bytes, []uint8{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
+	assert.Equal(t, len(tv.Bytes), 0)
 
-	tv = NewUint64(12345678)
+	tv = newUint64(big.NewInt(12345678), 32)
 	assert.Equal(t, tv.String(), fmt.Sprintf("%d", 12345678))
-	assert.Equal(t, len(tv.Bytes), 8)
-	assert.DeepEqual(t, tv.Bytes, []uint8{0x4E, 0x61, 0xBC, 0x0, 0x0, 0x0, 0x0, 0x0})
+	assert.Equal(t, len(tv.Bytes), 3)
+	assert.DeepEqual(t, tv.Bytes, []uint8{0xbc, 0x61, 0x4e})
 
-	tv = NewUint64(testMaxUint)
+	var bigInt big.Int
+	bigInt.SetUint64(testMaxUint)
+	tv = newUint64(&bigInt, 64)
 	assert.Equal(t, tv.String(), fmt.Sprintf("%d", testMaxUint))
 	assert.DeepEqual(t, tv.Bytes, []uint8{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
 
@@ -130,7 +133,7 @@ func Test_TypedValueUint(t *testing.T) {
 }
 
 func Test_TypedValueBool(t *testing.T) {
-	tv := NewBool(true)
+	tv := newBool(true)
 
 	assert.Equal(t, len(tv.Bytes), 1)
 	assert.Equal(t, tv.String(), "true")
@@ -138,50 +141,53 @@ func Test_TypedValueBool(t *testing.T) {
 
 	testConversion(t, (*TypedValue)(tv))
 
-	tv = NewBool(false)
+	tv = newBool(false)
 	assert.Equal(t, tv.String(), "false")
 	assert.Equal(t, (*TypedValue)(tv).ValueToString(), "false")
 }
 
 func Test_TypedValueDecimal64(t *testing.T) {
-	tv := NewDecimal64(testNegativeInt, testPrecision3)
+	tv := newDecimal64(big.NewInt(testNegativeInt64), testPrecision3)
 	assert.Equal(t, len(tv.Bytes), 8)
 	assert.Equal(t, tv.String(), "-9223372036854775.808")
 	assert.Equal(t, tv.TypeOpts[0], int32(testPrecision3))
-	assert.DeepEqual(t, tv.Bytes, []uint8{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x80})
+	assert.Equal(t, tv.TypeOpts[1], isNegativeTypeOpt)
+	assert.DeepEqual(t, tv.Bytes, []byte{0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
 
 	testConversion(t, (*TypedValue)(tv))
 
-	tv = NewDecimal64(testPositiveInt, testPrecision6)
+	tv = newDecimal64(big.NewInt(testPositiveInt64), testPrecision6)
 	assert.Equal(t, tv.String(), "9223372036854.775807")
 	assert.Equal(t, tv.TypeOpts[0], int32(testPrecision6))
-	assert.DeepEqual(t, tv.Bytes, []uint8{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F})
+	assert.Equal(t, tv.TypeOpts[1], isPositiveTypeOpt)
+	assert.DeepEqual(t, tv.Bytes, []byte{0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
 
-	tv = NewDecimal64(testDigitsZero, testPrecision0)
+	tv = newDecimal64(big.NewInt(int64(testDigitsZero)), testPrecision0)
 	assert.Equal(t, tv.String(), "0")
 	assert.Equal(t, tv.TypeOpts[0], int32(testPrecision0))
+	assert.Equal(t, tv.TypeOpts[1], isPositiveTypeOpt)
 	assert.Equal(t, (*TypedValue)(tv).ValueToString(), "0")
-	assert.DeepEqual(t, tv.Bytes, []uint8{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x00})
+	assert.DeepEqual(t, tv.Bytes, []byte{})
 }
 
 func Test_TypedValueFloat(t *testing.T) {
-	tv := NewFloat(testFloatNeg)
-	assert.Equal(t, len(tv.Bytes), 8)
+	tv := newFloat(big.NewFloat(testFloatNeg))
+	assert.Equal(t, len(tv.Bytes), 18)
 	assert.Equal(t, tv.String(), "-339999995214436424907732413799364296704.000000")
 	assert.Equal(t, len(tv.TypeOpts), 0)
-	assert.DeepEqual(t, tv.Bytes, []uint8{0x0, 0x0, 0x0, 0xC0, 0x33, 0xF9, 0xEF, 0xC7})
+	assert.DeepEqual(t, tv.Bytes, []uint8{0x01, 0x0b, 0x00, 0x00, 0x00, 0x35, 0x00, 0x00, 0x00, 0x80, 0xff, 0xc9, 0x9e, 0x3c, 0x66, 0xfd, 0x68, 0x00})
 
 	testConversion(t, (*TypedValue)(tv))
 
-	tv = NewFloat(testFloatPos)
+	tv = newFloat(big.NewFloat(testFloatPos))
 	assert.Equal(t, tv.String(), "339999995214436424907732413799364296704.000000")
 	assert.Equal(t, (*TypedValue)(tv).ValueToString(), "339999995214436424907732413799364296704.000000")
 	assert.Equal(t, len(tv.TypeOpts), 0)
-	assert.DeepEqual(t, tv.Bytes, []uint8{0x0, 0x0, 0x0, 0xC0, 0x33, 0xF9, 0xEF, 0x47})
+	assert.DeepEqual(t, tv.Bytes, []uint8{0x01, 0x0a, 0x00, 0x00, 0x00, 0x35, 0x00, 0x00, 0x00, 0x80, 0xff, 0xc9, 0x9e, 0x3c, 0x66, 0xfd, 0x68, 0x00})
 }
 
 func Test_TypedValueBytes(t *testing.T) {
-	tv := NewBytes([]byte(testStringBytes))
+	tv := newBytes([]byte(testStringBytes))
 	assert.Equal(t, len(tv.Bytes), 11)
 	assert.Equal(t, tv.String(), testStringBytesB64)
 
@@ -190,39 +196,40 @@ func Test_TypedValueBytes(t *testing.T) {
 }
 
 func Test_LeafListString(t *testing.T) {
-	tv := NewLeafListString(testLeafListString)
+	tv := newLeafListString(testLeafListString)
 	assert.Equal(t, len(tv.Bytes), 22)
 	assert.Equal(t, tv.String(), "abc,def,ghi,with,comma")
 	testConversion(t, (*TypedValue)(tv))
 
 	testArray := []string{"one"}
-	tv = NewLeafListString(testArray)
+	tv = newLeafListString(testArray)
 	assert.Equal(t, len(tv.Bytes), 3)
 	assert.Equal(t, tv.String(), "one")
 	assert.Equal(t, (*TypedValue)(tv).ValueToString(), "one")
 }
 
 func Test_LeafListInt64(t *testing.T) {
-	tv := NewLeafListInt64(testLeafListInt)
-	assert.Equal(t, len(tv.Bytes), 24)
-	assert.Equal(t, tv.String(), "[-9223372036854775808 0 9223372036854775807]")
-
+	tv := NewLeafListInt64Tv(testLeafListInt, WidthSixtyFour)
+	assert.Equal(t, len(tv.Bytes), 16)
+	assert.Equal(t, ValueType_LEAFLIST_INT, tv.Type)
+	assert.DeepEqual(t, []int32{64, 8, 1, 0, 0, 8, 0}, tv.TypeOpts)
 	testConversion(t, (*TypedValue)(tv))
-	assert.Equal(t, (*TypedValue)(tv).ValueToString(), "[-9223372036854775808 0 9223372036854775807]")
+	assert.Equal(t, (*TypedValue)(tv).ValueToString(), "[-9223372036854775808 0 9223372036854775807] 64")
 }
 
 func Test_LeafListUint64(t *testing.T) {
-	tv := NewLeafListUint64(testLeafListUint)
+	tv := NewLeafListUint64Tv(testLeafListUint, WidthSixtyFour)
 
-	assert.Equal(t, len(tv.Bytes), 24)
-	assert.Equal(t, tv.String(), "[0 11 18446744073709551615]")
+	assert.Equal(t, 9, len(tv.Bytes))
+	assert.Equal(t, ValueType_LEAFLIST_UINT, tv.Type)
+	assert.DeepEqual(t, []int32{64, 0, 1, 8}, tv.TypeOpts)
 
 	testConversion(t, (*TypedValue)(tv))
-	assert.Equal(t, (*TypedValue)(tv).ValueToString(), "[0 11 18446744073709551615]")
+	assert.Equal(t, (*TypedValue)(tv).ValueToString(), "[0 11 18446744073709551615] 64")
 }
 
 func Test_LeafListBool(t *testing.T) {
-	tv := NewLeafListBool(testLeafListBool)
+	tv := newLeafListBool(testLeafListBool)
 
 	assert.Equal(t, len(tv.Bytes), 4)
 	assert.Equal(t, tv.String(), "[true false false true]")
@@ -232,17 +239,22 @@ func Test_LeafListBool(t *testing.T) {
 }
 
 func Test_LeafListDecimal64(t *testing.T) {
-	tv := NewLeafListDecimal64(testLeafListDecimal, testPrecision6)
+	testLeafListDecimalBi := []*big.Int{
+		big.NewInt(testLeafListDecimal[0]),
+		big.NewInt(testLeafListDecimal[1]),
+		big.NewInt(testLeafListDecimal[2]),
+	}
+	tv := newLeafListDecimal64(testLeafListDecimalBi, testPrecision6)
 
-	assert.Equal(t, len(tv.Bytes), 24)
-	assert.Equal(t, tv.String(), "[-9223372036854775808 0 9223372036854775807] 6")
+	assert.Equal(t, len(tv.Bytes), 8)
+	assert.Equal(t, tv.String(), "[-2147483648 0 2147483647] 6")
 
 	testConversion(t, (*TypedValue)(tv))
-	assert.Equal(t, (*TypedValue)(tv).ValueToString(), "[-9223372036854775808 0 9223372036854775807] 6")
+	assert.Equal(t, (*TypedValue)(tv).ValueToString(), "[-2147483648 0 2147483647] 6")
 }
 
 func Test_LeafListFloat32(t *testing.T) {
-	tv := NewLeafListFloat32(testLeafListFloat)
+	tv := newLeafListFloat32(testLeafListFloat)
 
 	assert.Equal(t, len(tv.Bytes), 24)
 	assert.Equal(t, tv.String(), "-339999995214436424907732413799364296704.000000,0.000000,339999995214436424907732413799364296704.000000")
@@ -252,7 +264,7 @@ func Test_LeafListFloat32(t *testing.T) {
 }
 
 func Test_LeafListBytes(t *testing.T) {
-	tv := NewLeafListBytes(testLeafListBytes)
+	tv := newLeafListBytes(testLeafListBytes)
 
 	testConversion(t, (*TypedValue)(tv))
 
@@ -289,60 +301,107 @@ func Test_JsonSerializationDecimal(t *testing.T) {
 	jsonStr, err := json.Marshal(tv)
 	assert.NilError(t, err)
 
-	assert.Equal(t, string(jsonStr), `{"Bytes":"0AQAAAAAAAA=","Type":5,"TypeOpts":[6]}`)
+	assert.Equal(t, string(jsonStr), `{"Bytes":"BNA=","Type":5,"TypeOpts":[6,0]}`)
 
 	unmarshalledTv := TypedValue{}
 	err = json.Unmarshal(jsonStr, &unmarshalledTv)
 	assert.NilError(t, err)
 
 	assert.Equal(t, unmarshalledTv.Type, ValueType_DECIMAL)
-	assert.Equal(t, len(unmarshalledTv.TypeOpts), 1)
+	assert.Equal(t, len(unmarshalledTv.TypeOpts), 2)
 	assert.Equal(t, unmarshalledTv.TypeOpts[0], int32(6))
-	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0xd0, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
+	assert.Equal(t, unmarshalledTv.TypeOpts[1], int32(isPositiveTypeOpt))
+	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0x04, 0xd0})
 
 	decFloat := (*TypedDecimal64)(&unmarshalledTv).Float()
 	assert.Equal(t, decFloat, 0.001232)
 }
 
-func Test_JsonSerializationInt(t *testing.T) {
-	tv := NewTypedValueInt64(testNegativeInt)
+// From RFC-7951: A value of the "int64", "uint64", or "decimal64" type is represented as a JSON string
+func Test_JsonSerializationInt64(t *testing.T) {
+	tv := NewTypedValueInt64(testNegativeInt64, 64)
 
 	jsonStr, err := json.Marshal(tv)
 	assert.NilError(t, err)
 
-	assert.Equal(t, string(jsonStr), `{"Bytes":"AAAAAAAAAIA=","Type":2}`)
+	assert.Equal(t, string(jsonStr), `{"Bytes":"gAAAAAAAAAA=","Type":2,"TypeOpts":[64,1]}`)
 
 	unmarshalledTv := TypedValue{}
 	err = json.Unmarshal(jsonStr, &unmarshalledTv)
 	assert.NilError(t, err)
 
-	assert.Equal(t, unmarshalledTv.Type, ValueType_INT)
-	assert.Equal(t, len(unmarshalledTv.TypeOpts), 0)
-	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80})
+	assert.Equal(t, ValueType_INT, unmarshalledTv.Type)
+	assert.Equal(t, len(unmarshalledTv.TypeOpts), 2)
+	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
 
-	uintVal := (*TypedInt64)(&unmarshalledTv).Int()
-	assert.Equal(t, uintVal, testNegativeInt)
+	strVal := (*TypedInt64)(&unmarshalledTv).String()
+	assert.Equal(t, fmt.Sprintf("%d", testNegativeInt64), strVal)
 	assert.Equal(t, unmarshalledTv.ValueToString(), "-9223372036854775808")
 }
 
-func Test_JsonSerializationUint(t *testing.T) {
-	tv := NewTypedValueUint64(16)
+func Test_JsonSerializationInt32(t *testing.T) {
+	tv := NewTypedValueInt64(testNegativeInt32, 32)
 
 	jsonStr, err := json.Marshal(tv)
 	assert.NilError(t, err)
 
-	assert.Equal(t, string(jsonStr), `{"Bytes":"EAAAAAAAAAA=","Type":3}`)
+	assert.Equal(t, string(jsonStr), `{"Bytes":"gAAAAA==","Type":2,"TypeOpts":[32,1]}`)
+
+	unmarshalledTv := TypedValue{}
+	err = json.Unmarshal(jsonStr, &unmarshalledTv)
+	assert.NilError(t, err)
+
+	assert.Equal(t, ValueType_INT, unmarshalledTv.Type)
+	assert.Equal(t, len(unmarshalledTv.TypeOpts), 2)
+	assert.Equal(t, unmarshalledTv.TypeOpts[0], int32(32))
+	assert.Equal(t, unmarshalledTv.TypeOpts[1], isNegativeTypeOpt)
+	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0x80, 0x00, 0x00, 0x00})
+
+	intVal := (*TypedInt64)(&unmarshalledTv).Int()
+	assert.Equal(t, testNegativeInt32, intVal)
+	assert.Equal(t, unmarshalledTv.ValueToString(), "-2147483648")
+}
+
+func Test_JsonSerializationUint8(t *testing.T) {
+	tv := NewTypedValueUint64(16, 8)
+
+	jsonStr, err := json.Marshal(tv)
+	assert.NilError(t, err)
+
+	assert.Equal(t, string(jsonStr), `{"Bytes":"EA==","Type":3,"TypeOpts":[8]}`)
 
 	unmarshalledTv := TypedValue{}
 	err = json.Unmarshal(jsonStr, &unmarshalledTv)
 	assert.NilError(t, err)
 
 	assert.Equal(t, unmarshalledTv.Type, ValueType_UINT)
-	assert.Equal(t, len(unmarshalledTv.TypeOpts), 0)
-	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
+	assert.Equal(t, len(unmarshalledTv.TypeOpts), 1)
+	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0x10})
 
 	uintVal := (*TypedUint64)(&unmarshalledTv).Uint()
 	assert.Equal(t, uintVal, uint(16))
+}
+
+// From RFC-7951: A value of the "int64", "uint64", or "decimal64" type is represented as a JSON string
+func Test_JsonSerializationUint64(t *testing.T) {
+	tv := NewTypedValueUint64(testPositiveInt64, 64)
+
+	jsonStr, err := json.Marshal(tv)
+	assert.NilError(t, err)
+
+	assert.Equal(t, string(jsonStr), `{"Bytes":"f/////////8=","Type":3,"TypeOpts":[64]}`)
+
+	unmarshalledTv := TypedValue{}
+	err = json.Unmarshal(jsonStr, &unmarshalledTv)
+	assert.NilError(t, err)
+
+	assert.Equal(t, ValueType_UINT, unmarshalledTv.Type)
+	assert.Equal(t, len(unmarshalledTv.TypeOpts), 1)
+	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
+
+	strVal := (*TypedUint64)(&unmarshalledTv).String()
+	assert.Equal(t, fmt.Sprintf("%d", testPositiveInt64), strVal)
+	assert.Equal(t, unmarshalledTv.ValueToString(), "9223372036854775807")
 }
 
 func Test_JsonSerializationBool(t *testing.T) {
@@ -366,23 +425,22 @@ func Test_JsonSerializationBool(t *testing.T) {
 }
 
 func Test_JsonSerializationLeafListInt(t *testing.T) {
-	tv := NewLeafListInt64Tv(testLeafListInt)
-
+	tv := NewLeafListInt64Tv(testLeafListInt, WidthSixtyFour)
 	jsonStr, err := json.Marshal(tv)
 	assert.NilError(t, err)
 
-	assert.Equal(t, string(jsonStr), `{"Bytes":"AAAAAAAAAIAAAAAAAAAAAP////////9/","Type":9}`)
+	assert.Equal(t, string(jsonStr), `{"Bytes":"gAAAAAAAAAB//////////w==","Type":9,"TypeOpts":[64,8,1,0,0,8,0]}`)
 
 	unmarshalledTv := TypedValue{}
 	err = json.Unmarshal(jsonStr, &unmarshalledTv)
 	assert.NilError(t, err)
 
 	assert.Equal(t, unmarshalledTv.Type, ValueType_LEAFLIST_INT)
-	assert.Equal(t, len(unmarshalledTv.TypeOpts), 0)
-	assert.Equal(t, len(unmarshalledTv.Bytes), 24)
-	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f})
+	assert.Equal(t, len(unmarshalledTv.TypeOpts), 7)
+	assert.Equal(t, len(unmarshalledTv.Bytes), 16)
+	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
 
-	assert.Equal(t, (*TypedLeafListInt64)(&unmarshalledTv).String(), "[-9223372036854775808 0 9223372036854775807]")
+	assert.Equal(t, (*TypedLeafListInt64)(&unmarshalledTv).String(), "[-9223372036854775808 0 9223372036854775807] 64")
 }
 
 func Test_JsonSerializationLeafListBytes(t *testing.T) {
@@ -407,12 +465,35 @@ func Test_JsonSerializationLeafListBytes(t *testing.T) {
 	assert.Equal(t, (*TypedLeafListBytes)(&unmarshalledTv).String(), "[[97 98 99] [100 101 102 103] [103 104 105 106 107]]")
 }
 
-func Test_CreateFromBytesInt(t *testing.T) {
-	buf := make([]byte, 8)
-	binary.LittleEndian.PutUint64(buf, uint64(testPositiveInt))
+func Test_CreateFromBytesInt32(t *testing.T) {
+	var buf big.Int
+	buf.SetInt64(int64(testPositiveInt32))
 
-	tv, err := NewTypedValue(buf, ValueType_INT, nil)
+	tv, err := NewTypedValue(buf.Bytes(), ValueType_INT, []uint8{32, 0})
 	assert.NilError(t, err)
+	assert.Equal(t, 2, len(tv.TypeOpts))
+	assert.Equal(t, int32(32), tv.TypeOpts[0])
+	assert.Equal(t, tv.ValueToString(), "2147483647")
+}
+
+func Test_CreateFromBytesNegInt32(t *testing.T) {
+	var buf big.Int
+	buf.SetInt64(int64(testNegativeInt32))
+
+	tv, err := NewTypedValue(buf.Bytes(), ValueType_INT, []uint8{32, 1})
+	assert.NilError(t, err)
+	assert.Equal(t, 2, len(tv.TypeOpts))
+	assert.Equal(t, int32(32), tv.TypeOpts[0])
+	assert.Equal(t, tv.ValueToString(), "-2147483648")
+}
+
+func Test_CreateFromBytesInt64(t *testing.T) {
+	var buf big.Int
+	buf.SetInt64(int64(testPositiveInt64))
+
+	tv, err := NewTypedValue(buf.Bytes(), ValueType_INT, []uint8{64, 0})
+	assert.NilError(t, err)
+	assert.Equal(t, 2, len(tv.TypeOpts))
 	assert.Equal(t, tv.ValueToString(), "9223372036854775807")
 }
 
@@ -432,17 +513,17 @@ func testConversion(t *testing.T, tv *TypedValue) {
 	case ValueType_STRING:
 		assert.Equal(t, (*TypedString)(tv).String(), testString)
 	case ValueType_INT:
-		assert.Equal(t, (*TypedInt64)(tv).Int(), testNegativeInt)
+		assert.Equal(t, (*TypedInt64)(tv).Int(), testNegativeInt64)
 	case ValueType_UINT:
-		assert.Equal(t, (*TypedUint64)(tv).Uint(), testMaxUint)
+		assert.Equal(t, (*TypedUint64)(tv).Uint(), uint(testMaxUint))
 	case ValueType_BOOL:
 		assert.Equal(t, (*TypedBool)(tv).Bool(), true)
 	case ValueType_DECIMAL:
 		digits, precision := (*TypedDecimal64)(tv).Decimal64()
-		assert.Equal(t, digits, int64(testNegativeInt))
-		assert.Equal(t, precision, uint32(testPrecision3))
+		assert.Equal(t, digits, int64(testNegativeInt64))
+		assert.Equal(t, precision, uint8(testPrecision3))
 	case ValueType_FLOAT:
-		assert.Equal(t, (*TypedFloat)(tv).Float32(), testFloatNeg)
+		assert.Equal(t, (*TypedFloat)(tv).Float32(), float32(testFloatNeg))
 	case ValueType_BYTES:
 		assert.Equal(t, base64.StdEncoding.EncodeToString((*TypedBytes)(tv).ByteArray()), testStringBytesB64)
 		assert.Equal(t, len(tv.TypeOpts), 1)
@@ -450,15 +531,23 @@ func testConversion(t *testing.T, tv *TypedValue) {
 	case ValueType_LEAFLIST_STRING:
 		assert.DeepEqual(t, (*TypedLeafListString)(tv).List(), testLeafListString)
 	case ValueType_LEAFLIST_INT:
-		assert.DeepEqual(t, (*TypedLeafListInt64)(tv).List(), testLeafListInt)
+		list, width := (*TypedLeafListInt64)(tv).List()
+		assert.Equal(t, WidthSixtyFour, width)
+		assert.Equal(t, 3, len(list))
+		assert.DeepEqual(t, testLeafListInt, list)
 	case ValueType_LEAFLIST_UINT:
-		assert.DeepEqual(t, (*TypedLeafListUint)(tv).List(), testLeafListUint)
+		list, width := (*TypedLeafListUint)(tv).List()
+		assert.Equal(t, WidthSixtyFour, width)
+		assert.Equal(t, 3, len(list))
+		assert.DeepEqual(t, testLeafListUint, list)
 	case ValueType_LEAFLIST_BOOL:
 		assert.DeepEqual(t, (*TypedLeafListBool)(tv).List(), testLeafListBool)
 	case ValueType_LEAFLIST_DECIMAL:
 		digits, precision := (*TypedLeafListDecimal)(tv).List()
-		assert.DeepEqual(t, digits, testLeafListDecimal)
-		assert.Equal(t, precision, uint32(testPrecision6))
+		for i := range testLeafListDecimal {
+			assert.Equal(t, testLeafListDecimal[i], digits[i])
+		}
+		assert.Equal(t, precision, int32(testPrecision6))
 	case ValueType_LEAFLIST_FLOAT:
 		assert.DeepEqual(t, (*TypedLeafListFloat)(tv).List(), testLeafListFloat)
 	case ValueType_LEAFLIST_BYTES:

--- a/go/onos/config/change/device/typedvalue_test.go
+++ b/go/onos/config/change/device/typedvalue_test.go
@@ -90,40 +90,40 @@ func Test_TypedValueString(t *testing.T) {
 }
 
 func Test_TypedValueInt(t *testing.T) {
-	tv := newInt64(big.NewInt(testNegativeInt64), 64)
+	tv := newInt(big.NewInt(testNegativeInt64), 64)
 	assert.Equal(t, tv.String(), fmt.Sprintf("%d", testNegativeInt64))
 	assert.Equal(t, len(tv.Bytes), 8)
 	assert.DeepEqual(t, tv.Bytes, []uint8{0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
 
 	testConversion(t, (*TypedValue)(tv))
 
-	tv = newInt64(big.NewInt(12345678), 32)
+	tv = newInt(big.NewInt(12345678), 32)
 	assert.Equal(t, tv.String(), fmt.Sprintf("%d", 12345678))
 	assert.DeepEqual(t, tv.Bytes, []uint8{0xbc, 0x61, 0x4e})
 
-	tv = newInt64(big.NewInt(testPositiveInt64), 64)
+	tv = newInt(big.NewInt(testPositiveInt64), 64)
 	assert.Equal(t, tv.String(), fmt.Sprintf("%d", testPositiveInt64))
 	assert.DeepEqual(t, tv.Bytes, []uint8{0x7f, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
 
-	tv = newInt64(big.NewInt(testZeroInt), 32)
+	tv = newInt(big.NewInt(testZeroInt), 32)
 	assert.Equal(t, tv.String(), fmt.Sprintf("%d", testZeroInt))
 	assert.Equal(t, (*TypedValue)(tv).ValueToString(), "0")
 	assert.DeepEqual(t, tv.Bytes, []uint8{})
 }
 
 func Test_TypedValueUint(t *testing.T) {
-	tv := newUint64(big.NewInt(testZeroUint), 8)
+	tv := newUint(big.NewInt(testZeroUint), 8)
 	assert.Equal(t, tv.String(), fmt.Sprintf("%d", testZeroUint))
 	assert.Equal(t, len(tv.Bytes), 0)
 
-	tv = newUint64(big.NewInt(12345678), 32)
+	tv = newUint(big.NewInt(12345678), 32)
 	assert.Equal(t, tv.String(), fmt.Sprintf("%d", 12345678))
 	assert.Equal(t, len(tv.Bytes), 3)
 	assert.DeepEqual(t, tv.Bytes, []uint8{0xbc, 0x61, 0x4e})
 
 	var bigInt big.Int
 	bigInt.SetUint64(testMaxUint)
-	tv = newUint64(&bigInt, 64)
+	tv = newUint(&bigInt, 64)
 	assert.Equal(t, tv.String(), fmt.Sprintf("%d", testMaxUint))
 	assert.DeepEqual(t, tv.Bytes, []uint8{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
 
@@ -147,7 +147,7 @@ func Test_TypedValueBool(t *testing.T) {
 }
 
 func Test_TypedValueDecimal64(t *testing.T) {
-	tv := newDecimal64(big.NewInt(testNegativeInt64), testPrecision3)
+	tv := newDecimal(big.NewInt(testNegativeInt64), testPrecision3)
 	assert.Equal(t, len(tv.Bytes), 8)
 	assert.Equal(t, tv.String(), "-9223372036854775.808")
 	assert.Equal(t, tv.TypeOpts[0], int32(testPrecision3))
@@ -156,13 +156,13 @@ func Test_TypedValueDecimal64(t *testing.T) {
 
 	testConversion(t, (*TypedValue)(tv))
 
-	tv = newDecimal64(big.NewInt(testPositiveInt64), testPrecision6)
+	tv = newDecimal(big.NewInt(testPositiveInt64), testPrecision6)
 	assert.Equal(t, tv.String(), "9223372036854.775807")
 	assert.Equal(t, tv.TypeOpts[0], int32(testPrecision6))
 	assert.Equal(t, tv.TypeOpts[1], isPositiveTypeOpt)
 	assert.DeepEqual(t, tv.Bytes, []byte{0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
 
-	tv = newDecimal64(big.NewInt(int64(testDigitsZero)), testPrecision0)
+	tv = newDecimal(big.NewInt(int64(testDigitsZero)), testPrecision0)
 	assert.Equal(t, tv.String(), "0")
 	assert.Equal(t, tv.TypeOpts[0], int32(testPrecision0))
 	assert.Equal(t, tv.TypeOpts[1], isPositiveTypeOpt)
@@ -209,7 +209,7 @@ func Test_LeafListString(t *testing.T) {
 }
 
 func Test_LeafListInt64(t *testing.T) {
-	tv := NewLeafListInt64Tv(testLeafListInt, WidthSixtyFour)
+	tv := NewLeafListIntTv(testLeafListInt, WidthSixtyFour)
 	assert.Equal(t, len(tv.Bytes), 16)
 	assert.Equal(t, ValueType_LEAFLIST_INT, tv.Type)
 	assert.DeepEqual(t, []int32{64, 8, 1, 0, 0, 8, 0}, tv.TypeOpts)
@@ -218,7 +218,7 @@ func Test_LeafListInt64(t *testing.T) {
 }
 
 func Test_LeafListUint64(t *testing.T) {
-	tv := NewLeafListUint64Tv(testLeafListUint, WidthSixtyFour)
+	tv := NewLeafListUintTv(testLeafListUint, WidthSixtyFour)
 
 	assert.Equal(t, 9, len(tv.Bytes))
 	assert.Equal(t, ValueType_LEAFLIST_UINT, tv.Type)
@@ -244,7 +244,7 @@ func Test_LeafListDecimal64(t *testing.T) {
 		big.NewInt(testLeafListDecimal[1]),
 		big.NewInt(testLeafListDecimal[2]),
 	}
-	tv := newLeafListDecimal64(testLeafListDecimalBi, testPrecision6)
+	tv := newLeafListDecimal(testLeafListDecimalBi, testPrecision6)
 
 	assert.Equal(t, len(tv.Bytes), 8)
 	assert.Equal(t, tv.String(), "[-2147483648 0 2147483647] 6")
@@ -254,7 +254,7 @@ func Test_LeafListDecimal64(t *testing.T) {
 }
 
 func Test_LeafListFloat32(t *testing.T) {
-	tv := newLeafListFloat32(testLeafListFloat)
+	tv := newLeafListFloat(testLeafListFloat)
 
 	assert.Equal(t, len(tv.Bytes), 24)
 	assert.Equal(t, tv.String(), "-339999995214436424907732413799364296704.000000,0.000000,339999995214436424907732413799364296704.000000")
@@ -296,7 +296,7 @@ func Test_JsonSerializationString(t *testing.T) {
 }
 
 func Test_JsonSerializationDecimal(t *testing.T) {
-	tv := NewTypedValueDecimal64(1232, 6)
+	tv := NewTypedValueDecimal(1232, 6)
 
 	jsonStr, err := json.Marshal(tv)
 	assert.NilError(t, err)
@@ -313,13 +313,13 @@ func Test_JsonSerializationDecimal(t *testing.T) {
 	assert.Equal(t, unmarshalledTv.TypeOpts[1], int32(isPositiveTypeOpt))
 	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0x04, 0xd0})
 
-	decFloat := (*TypedDecimal64)(&unmarshalledTv).Float()
+	decFloat := (*TypedDecimal)(&unmarshalledTv).Float()
 	assert.Equal(t, decFloat, 0.001232)
 }
 
 // From RFC-7951: A value of the "int64", "uint64", or "decimal64" type is represented as a JSON string
 func Test_JsonSerializationInt64(t *testing.T) {
-	tv := NewTypedValueInt64(testNegativeInt64, 64)
+	tv := NewTypedValueInt(testNegativeInt64, 64)
 
 	jsonStr, err := json.Marshal(tv)
 	assert.NilError(t, err)
@@ -334,13 +334,13 @@ func Test_JsonSerializationInt64(t *testing.T) {
 	assert.Equal(t, len(unmarshalledTv.TypeOpts), 2)
 	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00})
 
-	strVal := (*TypedInt64)(&unmarshalledTv).String()
+	strVal := (*TypedInt)(&unmarshalledTv).String()
 	assert.Equal(t, fmt.Sprintf("%d", testNegativeInt64), strVal)
 	assert.Equal(t, unmarshalledTv.ValueToString(), "-9223372036854775808")
 }
 
 func Test_JsonSerializationInt32(t *testing.T) {
-	tv := NewTypedValueInt64(testNegativeInt32, 32)
+	tv := NewTypedValueInt(testNegativeInt32, 32)
 
 	jsonStr, err := json.Marshal(tv)
 	assert.NilError(t, err)
@@ -357,13 +357,13 @@ func Test_JsonSerializationInt32(t *testing.T) {
 	assert.Equal(t, unmarshalledTv.TypeOpts[1], isNegativeTypeOpt)
 	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0x80, 0x00, 0x00, 0x00})
 
-	intVal := (*TypedInt64)(&unmarshalledTv).Int()
+	intVal := (*TypedInt)(&unmarshalledTv).Int()
 	assert.Equal(t, testNegativeInt32, intVal)
 	assert.Equal(t, unmarshalledTv.ValueToString(), "-2147483648")
 }
 
 func Test_JsonSerializationUint8(t *testing.T) {
-	tv := NewTypedValueUint64(16, 8)
+	tv := NewTypedValueUint(16, 8)
 
 	jsonStr, err := json.Marshal(tv)
 	assert.NilError(t, err)
@@ -378,13 +378,13 @@ func Test_JsonSerializationUint8(t *testing.T) {
 	assert.Equal(t, len(unmarshalledTv.TypeOpts), 1)
 	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0x10})
 
-	uintVal := (*TypedUint64)(&unmarshalledTv).Uint()
+	uintVal := (*TypedUint)(&unmarshalledTv).Uint()
 	assert.Equal(t, uintVal, uint(16))
 }
 
 // From RFC-7951: A value of the "int64", "uint64", or "decimal64" type is represented as a JSON string
 func Test_JsonSerializationUint64(t *testing.T) {
-	tv := NewTypedValueUint64(testPositiveInt64, 64)
+	tv := NewTypedValueUint(testPositiveInt64, 64)
 
 	jsonStr, err := json.Marshal(tv)
 	assert.NilError(t, err)
@@ -399,7 +399,7 @@ func Test_JsonSerializationUint64(t *testing.T) {
 	assert.Equal(t, len(unmarshalledTv.TypeOpts), 1)
 	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
 
-	strVal := (*TypedUint64)(&unmarshalledTv).String()
+	strVal := (*TypedUint)(&unmarshalledTv).String()
 	assert.Equal(t, fmt.Sprintf("%d", testPositiveInt64), strVal)
 	assert.Equal(t, unmarshalledTv.ValueToString(), "9223372036854775807")
 }
@@ -425,7 +425,7 @@ func Test_JsonSerializationBool(t *testing.T) {
 }
 
 func Test_JsonSerializationLeafListInt(t *testing.T) {
-	tv := NewLeafListInt64Tv(testLeafListInt, WidthSixtyFour)
+	tv := NewLeafListIntTv(testLeafListInt, WidthSixtyFour)
 	jsonStr, err := json.Marshal(tv)
 	assert.NilError(t, err)
 
@@ -440,7 +440,7 @@ func Test_JsonSerializationLeafListInt(t *testing.T) {
 	assert.Equal(t, len(unmarshalledTv.Bytes), 16)
 	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})
 
-	assert.Equal(t, (*TypedLeafListInt64)(&unmarshalledTv).String(), "[-9223372036854775808 0 9223372036854775807] 64")
+	assert.Equal(t, (*TypedLeafListInt)(&unmarshalledTv).String(), "[-9223372036854775808 0 9223372036854775807] 64")
 }
 
 func Test_JsonSerializationLeafListBytes(t *testing.T) {
@@ -513,13 +513,13 @@ func testConversion(t *testing.T, tv *TypedValue) {
 	case ValueType_STRING:
 		assert.Equal(t, (*TypedString)(tv).String(), testString)
 	case ValueType_INT:
-		assert.Equal(t, (*TypedInt64)(tv).Int(), testNegativeInt64)
+		assert.Equal(t, (*TypedInt)(tv).Int(), testNegativeInt64)
 	case ValueType_UINT:
-		assert.Equal(t, (*TypedUint64)(tv).Uint(), uint(testMaxUint))
+		assert.Equal(t, (*TypedUint)(tv).Uint(), uint(testMaxUint))
 	case ValueType_BOOL:
 		assert.Equal(t, (*TypedBool)(tv).Bool(), true)
 	case ValueType_DECIMAL:
-		digits, precision := (*TypedDecimal64)(tv).Decimal64()
+		digits, precision := (*TypedDecimal)(tv).Decimal64()
 		assert.Equal(t, digits, int64(testNegativeInt64))
 		assert.Equal(t, precision, uint8(testPrecision3))
 	case ValueType_FLOAT:
@@ -531,7 +531,7 @@ func testConversion(t *testing.T, tv *TypedValue) {
 	case ValueType_LEAFLIST_STRING:
 		assert.DeepEqual(t, (*TypedLeafListString)(tv).List(), testLeafListString)
 	case ValueType_LEAFLIST_INT:
-		list, width := (*TypedLeafListInt64)(tv).List()
+		list, width := (*TypedLeafListInt)(tv).List()
 		assert.Equal(t, WidthSixtyFour, width)
 		assert.Equal(t, 3, len(list))
 		assert.DeepEqual(t, testLeafListInt, list)
@@ -547,7 +547,7 @@ func testConversion(t *testing.T, tv *TypedValue) {
 		for i := range testLeafListDecimal {
 			assert.Equal(t, testLeafListDecimal[i], digits[i])
 		}
-		assert.Equal(t, precision, int32(testPrecision6))
+		assert.Equal(t, precision, uint8(testPrecision6))
 	case ValueType_LEAFLIST_FLOAT:
 		assert.DeepEqual(t, (*TypedLeafListFloat)(tv).List(), testLeafListFloat)
 	case ValueType_LEAFLIST_BYTES:

--- a/go/onos/config/change/device/values_test.go
+++ b/go/onos/config/change/device/values_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"gotest.tools/assert"
 	"math"
+	"math/big"
 	"strings"
 	"testing"
 )
@@ -27,7 +28,7 @@ import (
 func Test_NewChangedValue(t *testing.T) {
 	path := "/a/b/c"
 	badPath := "a@b@c"
-	value := NewTypedValueUint64(64)
+	value := NewTypedValueUint64(64, 32)
 	const isRemove = false
 	changeValueBad, errorBad := NewChangeValue(badPath, value, isRemove)
 	assert.Assert(t, errorBad != nil)
@@ -42,21 +43,27 @@ func Test_NewChangedValue(t *testing.T) {
 
 func Test_NewValueTypeString(t *testing.T) {
 	const value = "xyzzy"
-	typedValue, err := NewTypedValue([]byte(value), ValueType_STRING, make([]int32, 0))
+	typedValue, err := NewTypedValue([]byte(value), ValueType_STRING, make([]uint8, 0))
 	assert.NilError(t, err)
 	assert.Equal(t, typedValue.ValueToString(), value)
 }
 
 func floatToBinary(value float64, size int) []byte {
 	bs := make([]byte, size)
-	binary.LittleEndian.PutUint64(bs, math.Float64bits(3.0))
+	binary.LittleEndian.PutUint64(bs, math.Float64bits(value))
 	return bs
 }
 
-func uintToBinary(value uint64, size int) []byte {
-	bs := make([]byte, size)
-	binary.LittleEndian.PutUint64(bs, value)
-	return bs
+func uintToBinary(value uint64) []byte {
+	var bigInt big.Int
+	bigInt.SetUint64(value)
+	return bigInt.Bytes()
+}
+
+func intToBinary(value int64) []byte {
+	var bigInt big.Int
+	bigInt.SetInt64(value)
+	return bigInt.Bytes()
 }
 
 func boolToBinary(value bool, size int) []byte {
@@ -78,7 +85,7 @@ func TestValueTypes(t *testing.T) {
 		valueType     ValueType
 		expectedValue string
 		expectedError string
-		typeOpts      []int32
+		typeOpts      []uint8
 	}{
 		{
 			description:   "NewValueEmpty",
@@ -113,38 +120,39 @@ func TestValueTypes(t *testing.T) {
 			value:         floatToBinary(3.0, 12),
 			valueType:     ValueType_FLOAT,
 			expectedValue: fmt.Sprintf("%f", 3.0),
-			expectedError: "Expecting 8 bytes for FLOAT. Got 12",
+			expectedError: "expecting 8 bytes for FLOAT. Got 12",
 		},
 		{
 			description:   "NewValueTypeUintSuccess",
-			value:         uintToBinary(345678, 8),
+			value:         uintToBinary(345678),
 			valueType:     ValueType_UINT,
+			typeOpts:      []uint8{32},
 			expectedValue: "345678",
 			expectedError: "",
 		},
 		{
 			description:   "NewValueTypeUintFailure",
-			value:         uintToBinary(345678, 12),
+			value:         uintToBinary(345678),
 			valueType:     ValueType_UINT,
-			expectedValue: "345678",
-			expectedError: "Expecting 8 bytes for UINT. Got 12",
+			expectedError: "number width must be given for UINT as type opts. []",
 		},
 		{
 			description:   "NewValueTypeIntSuccess",
-			value:         uintToBinary(345678, 8),
+			value:         intToBinary(345678),
 			valueType:     ValueType_INT,
+			typeOpts:      []uint8{32, 0},
 			expectedValue: "345678",
 			expectedError: "",
 		},
 		{
 			description:   "NewValueTypeIntFailure",
-			value:         uintToBinary(345678, 12),
+			value:         intToBinary(345678),
 			valueType:     ValueType_INT,
 			expectedValue: "345678",
-			expectedError: "Expecting 8 bytes for INT. Got 12",
+			expectedError: "number width AND sign must be given for INT as type opts. []",
 		},
 		{
-			description:   "NewValueTypeIntSuccess",
+			description:   "NewValueTypeBoolSuccess",
 			value:         boolToBinary(true, 1),
 			valueType:     ValueType_BOOL,
 			expectedValue: "true",
@@ -155,23 +163,31 @@ func TestValueTypes(t *testing.T) {
 			value:         boolToBinary(true, 2),
 			valueType:     ValueType_BOOL,
 			expectedValue: "",
-			expectedError: "Expecting 1 byte for BOOL. Got 2",
+			expectedError: "expecting 1 byte for BOOL. Got 2",
 		},
 		{
 			description:   "NewValueTypeDecimalSuccess",
-			value:         uintToBinary(1234, 8),
+			value:         intToBinary(1234),
 			valueType:     ValueType_DECIMAL,
-			typeOpts:      []int32{0},
+			typeOpts:      []uint8{0, 0},
 			expectedValue: "1234",
 			expectedError: "",
 		},
 		{
-			description:   "NewValueTypeDecimalFailure",
-			value:         uintToBinary(1234, 12),
+			description:   "NewValueTypeDecimalNegSuccess",
+			value:         intToBinary(-1234),
 			valueType:     ValueType_DECIMAL,
-			typeOpts:      []int32{3},
+			typeOpts:      []uint8{2, 1},
+			expectedValue: "-12.34",
+			expectedError: "",
+		},
+		{
+			description:   "NewValueTypeDecimalFailure",
+			value:         intToBinary(1234),
+			valueType:     ValueType_DECIMAL,
+			typeOpts:      []uint8{3},
 			expectedValue: "",
-			expectedError: "Expecting 8 bytes for DECIMAL. Got 12",
+			expectedError: "precision AND sign must be given for DECIMAL as type opts. [3]",
 		},
 		{
 			description:   "NewValueTypeLeafListString",
@@ -183,23 +199,25 @@ func TestValueTypes(t *testing.T) {
 		{
 			description: "NewValueTypeLeafListInt",
 			value: []byte{
-				11, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-				22, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-				33, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+				11,
+				22,
+				33,
 			},
 			valueType:     ValueType_LEAFLIST_INT,
-			expectedValue: "[11 22 33]",
+			typeOpts:      []uint8{8, 1, 0, 1, 0, 1, 0},
+			expectedValue: "[11 22 33] 8",
 			expectedError: "",
 		},
 		{
 			description: "NewValueTypeLeafListUint",
 			value: []byte{
-				3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-				5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-				7, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+				3,
+				5,
+				7,
 			},
 			valueType:     ValueType_LEAFLIST_UINT,
-			expectedValue: "[3 5 7]",
+			typeOpts:      []uint8{8, 1, 1, 1},
+			expectedValue: "[3 5 7] 8",
 			expectedError: "",
 		},
 		{
@@ -213,26 +231,26 @@ func TestValueTypes(t *testing.T) {
 		},
 		{
 			description:   "NewValueTypeLeafListDecimal",
-			value:         append(uintToBinary(1234, 8), uintToBinary(1234, 8)...),
+			value:         append(intToBinary(1234), intToBinary(-4321)...),
 			valueType:     ValueType_LEAFLIST_DECIMAL,
-			typeOpts:      []int32{0},
-			expectedValue: "[1234 1234] 0",
+			typeOpts:      []uint8{2, 2, 0, 2, 1},
+			expectedValue: "[1234 -4321] 2",
 			expectedError: "",
 		},
 		{
 			description:   "NewValueTypeLeafListBytes",
 			value:         []byte("12345678"),
 			valueType:     ValueType_LEAFLIST_BYTES,
-			typeOpts:      []int32{4, 4},
+			typeOpts:      []uint8{4, 4},
 			expectedValue: "[[49 50 51 52] [53 54 55 56]]",
 			expectedError: "",
 		},
 		{
 			description:   "NewValueTypeLeafListFloat",
-			value:         append(floatToBinary(1234, 8), floatToBinary(1234, 8)...),
+			value:         append(floatToBinary(12.34, 8), floatToBinary(-1.234, 8)...),
 			valueType:     ValueType_LEAFLIST_FLOAT,
-			typeOpts:      []int32{0},
-			expectedValue: "3.000000,3.000000",
+			typeOpts:      []uint8{0},
+			expectedValue: "12.340000,-1.234000",
 			expectedError: "",
 		},
 	}
@@ -251,49 +269,51 @@ func TestValueTypes(t *testing.T) {
 }
 
 func TestTypedEmpty(t *testing.T) {
-	empty := NewEmpty()
+	empty := newEmpty()
 	assert.Equal(t, empty.ValueType(), ValueType_EMPTY)
 	assert.Equal(t, empty.String(), "")
 }
 
 func TestTypedInt(t *testing.T) {
-	intValue := NewInt64(112233)
+	intValue := newInt64(big.NewInt(112233), 32)
 	assert.Equal(t, intValue.ValueType(), ValueType_INT)
 	assert.Equal(t, intValue.String(), "112233")
 	assert.Equal(t, intValue.Int(), 112233)
 }
 
 func TestTypedUint(t *testing.T) {
-	intValue := NewUint64(112233)
+	var bigInt big.Int
+	bigInt.SetUint64(112233)
+	intValue := newUint64(&bigInt, 32)
 	assert.Equal(t, intValue.ValueType(), ValueType_UINT)
 	assert.Equal(t, intValue.String(), "112233")
 	assert.Equal(t, uint64(intValue.Uint()), uint64(112233))
 }
 
 func TestTypedString(t *testing.T) {
-	intValue := NewString("xyzzy")
+	intValue := newString("xyzzy")
 	assert.Equal(t, intValue.ValueType(), ValueType_STRING)
 	assert.Equal(t, intValue.String(), "xyzzy")
 }
 
 func TestTypedBool(t *testing.T) {
-	boolValue := NewBool(false)
+	boolValue := newBool(false)
 	assert.Equal(t, boolValue.ValueType(), ValueType_BOOL)
 	assert.Equal(t, boolValue.String(), "false")
 	assert.Equal(t, boolValue.Bool(), false)
 }
 
 func TestTypedDecimal(t *testing.T) {
-	decimal64Value := NewDecimal64(1234, 2)
+	decimal64Value := newDecimal64(big.NewInt(1234), 2)
 	assert.Equal(t, decimal64Value.ValueType(), ValueType_DECIMAL)
 	assert.Equal(t, decimal64Value.String(), "12.34")
 	digits, precision := decimal64Value.Decimal64()
 	assert.Equal(t, int(digits), 1234)
-	assert.Equal(t, precision, uint32(2))
+	assert.Equal(t, precision, uint8(2))
 }
 
 func TestTypedFloat(t *testing.T) {
-	float64Value := NewFloat(2222.0)
+	float64Value := newFloat(big.NewFloat(2222.0))
 	assert.Equal(t, float64Value.ValueType(), ValueType_FLOAT)
 	assert.Equal(t, float64Value.String(), "2222.000000")
 	assert.Equal(t, float64Value.Float32(), float32(2222.0))
@@ -301,7 +321,7 @@ func TestTypedFloat(t *testing.T) {
 
 func TestTypedByte(t *testing.T) {
 	bytes := []byte("bytes")
-	bytesValue := NewBytes(bytes)
+	bytesValue := newBytes(bytes)
 	assert.Equal(t, bytesValue.ValueType(), ValueType_BYTES)
 	assert.Equal(t, bytesValue.String(), "Ynl0ZXM=")
 	assert.Equal(t, len(bytesValue.ByteArray()), len(bytes))
@@ -309,37 +329,38 @@ func TestTypedByte(t *testing.T) {
 
 func TestTypedLeafListString(t *testing.T) {
 	values := []string{"a", "b"}
-	listValue := NewLeafListString(values)
+	listValue := newLeafListString(values)
 	assert.Equal(t, listValue.ValueType(), ValueType_LEAFLIST_STRING)
 }
 
 func TestTypedLeafListUint(t *testing.T) {
-	values := []uint{1, 2}
-	listValue := NewLeafListUint64(values)
+	values := []*big.Int{big.NewInt(1), big.NewInt(2)}
+	listValue := newLeafListUint64(values, WidthThirtyTwo)
 	assert.Equal(t, listValue.ValueType(), ValueType_LEAFLIST_UINT)
 }
 
 func TestTypedLeafListInt(t *testing.T) {
-	values := []int{1, 2}
-	listValue := NewLeafListInt64(values)
+	values := []*big.Int{big.NewInt(1), big.NewInt(2)}
+	listValue := newLeafListInt64(values, WidthThirtyTwo)
 	assert.Equal(t, listValue.ValueType(), ValueType_LEAFLIST_INT)
 }
 
 func TestTypedLeafListBool(t *testing.T) {
 	values := []bool{true, false}
-	listValue := NewLeafListBool(values)
+	listValue := newLeafListBool(values)
 	assert.Equal(t, listValue.ValueType(), ValueType_LEAFLIST_BOOL)
 }
 
 func TestTypedLeafListFloat(t *testing.T) {
 	values := []float32{111.0, 112.0}
-	listValue := NewLeafListFloat32(values)
+	listValue := newLeafListFloat32(values)
 	assert.Equal(t, listValue.ValueType(), ValueType_LEAFLIST_FLOAT)
 }
 
 func TestTypedLeafListDecimal(t *testing.T) {
-	digits := []int64{22, 33}
-	listValue := NewLeafListDecimal64(digits, 2)
+	digits := []*big.Int{big.NewInt(22), big.NewInt(33)}
+
+	listValue := newLeafListDecimal64(digits, 2)
 	assert.Equal(t, listValue.ValueType(), ValueType_LEAFLIST_DECIMAL)
 	floats := listValue.ListFloat()
 	assert.Equal(t, len(floats), len(digits))
@@ -352,13 +373,13 @@ func TestTypedLeafListBytes(t *testing.T) {
 	values[0] = []byte("abc")
 	values[1] = []byte("xyz")
 
-	listValue := NewLeafListBytes(values)
+	listValue := newLeafListBytes(values)
 	assert.Equal(t, listValue.ValueType(), ValueType_LEAFLIST_BYTES)
 }
 
 func TestLeafListBytesCrash(t *testing.T) {
 	bytes := []byte("12345678")
-	typeOpts := []int32{4}
+	typeOpts := []uint8{4}
 	value, err := NewTypedValue(bytes, ValueType_LEAFLIST_BYTES, typeOpts)
 	assert.Assert(t, value == nil)
 	assert.Assert(t, err != nil)

--- a/go/onos/config/change/device/values_test.go
+++ b/go/onos/config/change/device/values_test.go
@@ -28,7 +28,7 @@ import (
 func Test_NewChangedValue(t *testing.T) {
 	path := "/a/b/c"
 	badPath := "a@b@c"
-	value := NewTypedValueUint64(64, 32)
+	value := NewTypedValueUint(64, 32)
 	const isRemove = false
 	changeValueBad, errorBad := NewChangeValue(badPath, value, isRemove)
 	assert.Assert(t, errorBad != nil)
@@ -275,7 +275,7 @@ func TestTypedEmpty(t *testing.T) {
 }
 
 func TestTypedInt(t *testing.T) {
-	intValue := newInt64(big.NewInt(112233), 32)
+	intValue := newInt(big.NewInt(112233), 32)
 	assert.Equal(t, intValue.ValueType(), ValueType_INT)
 	assert.Equal(t, intValue.String(), "112233")
 	assert.Equal(t, intValue.Int(), 112233)
@@ -284,7 +284,7 @@ func TestTypedInt(t *testing.T) {
 func TestTypedUint(t *testing.T) {
 	var bigInt big.Int
 	bigInt.SetUint64(112233)
-	intValue := newUint64(&bigInt, 32)
+	intValue := newUint(&bigInt, 32)
 	assert.Equal(t, intValue.ValueType(), ValueType_UINT)
 	assert.Equal(t, intValue.String(), "112233")
 	assert.Equal(t, uint64(intValue.Uint()), uint64(112233))
@@ -304,7 +304,7 @@ func TestTypedBool(t *testing.T) {
 }
 
 func TestTypedDecimal(t *testing.T) {
-	decimal64Value := newDecimal64(big.NewInt(1234), 2)
+	decimal64Value := newDecimal(big.NewInt(1234), 2)
 	assert.Equal(t, decimal64Value.ValueType(), ValueType_DECIMAL)
 	assert.Equal(t, decimal64Value.String(), "12.34")
 	digits, precision := decimal64Value.Decimal64()
@@ -335,13 +335,13 @@ func TestTypedLeafListString(t *testing.T) {
 
 func TestTypedLeafListUint(t *testing.T) {
 	values := []*big.Int{big.NewInt(1), big.NewInt(2)}
-	listValue := newLeafListUint64(values, WidthThirtyTwo)
+	listValue := newLeafListUint(values, WidthThirtyTwo)
 	assert.Equal(t, listValue.ValueType(), ValueType_LEAFLIST_UINT)
 }
 
 func TestTypedLeafListInt(t *testing.T) {
 	values := []*big.Int{big.NewInt(1), big.NewInt(2)}
-	listValue := newLeafListInt64(values, WidthThirtyTwo)
+	listValue := newLeafListInt(values, WidthThirtyTwo)
 	assert.Equal(t, listValue.ValueType(), ValueType_LEAFLIST_INT)
 }
 
@@ -353,14 +353,14 @@ func TestTypedLeafListBool(t *testing.T) {
 
 func TestTypedLeafListFloat(t *testing.T) {
 	values := []float32{111.0, 112.0}
-	listValue := newLeafListFloat32(values)
+	listValue := newLeafListFloat(values)
 	assert.Equal(t, listValue.ValueType(), ValueType_LEAFLIST_FLOAT)
 }
 
 func TestTypedLeafListDecimal(t *testing.T) {
 	digits := []*big.Int{big.NewInt(22), big.NewInt(33)}
 
-	listValue := newLeafListDecimal64(digits, 2)
+	listValue := newLeafListDecimal(digits, 2)
 	assert.Equal(t, listValue.ValueType(), ValueType_LEAFLIST_DECIMAL)
 	floats := listValue.ListFloat()
 	assert.Equal(t, len(floats), len(digits))


### PR DESCRIPTION
In onos-config the decoding of JSON follows RFC-7951 which needs int64 and uint64 to be represented as string rather than a number. For smaller widths they can be treated as number. 

When YGOT is validating it goes through the model and expects the JSON encoded data to suit the data type given. 

Basically the type cannot be deduced from the value alone. 

This PR used the "TypeOpts" field of the TypedValue to hold the number width, so that it can be used at encoding time.

There is a corresponding change in onos-config coming soon