### PR TITLE
Add setup.py for building python bindings package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+# SPDX-FileCopyrightText: © 2020 Open Networking Foundation <support@opennetworking.org>
+# SPDX-License-Identifier: Apache-2.0
+
+from setuptools import find_packages, setup
+
+
+PACKAGES = find_packages("python")
+
+
+def version():
+    with open("VERSION") as f:
+        return f.read()
+
+
+setup(
+    name="onos-api",
+    version=version(),
+    description="ONOS API for Python",
+    author="Open Networking Foundation and Partners",
+    author_email="support@opennetworking.org",
+    packages=[f"onos_api.{pkg}" for pkg in PACKAGES],
+    package_dir={f"onos_api.{pkg}": f"python/{pkg}".replace(".", "/") for pkg in PACKAGES},
+    install_requires=["betterproto>=2.0.0b3,<3.0"],
+    classifiers=[
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+    ],
+)
+
+


### PR DESCRIPTION
Installing the package and importing works.

```
(my_venv) omikader@omikader-mbp onos-api % pip install .
Processing /Users/omikader/onos-api
Collecting betterproto<3.0,>=2.0.0b3 (from onos-api==0.7.24.dev0)
  Downloading https://files.pythonhosted.org/packages/ec/f1/099946e44e1e5d11c05000f8efa799107272d1c1cb54f32aa2d509cd6309/betterproto-2.0.0b3-py3-none-any.whl (59kB)
     |████████████████████████████████| 61kB 462kB/s
Collecting grpclib<0.5.0,>=0.4.1 (from betterproto<3.0,>=2.0.0b3->onos-api==0.7.24.dev0)
Collecting python-dateutil<3.0,>=2.8 (from betterproto<3.0,>=2.0.0b3->onos-api==0.7.24.dev0)
  Using cached https://files.pythonhosted.org/packages/d4/70/d60450c3dd48ef87586924207ae8907090de0b306af2bce5d134d78615cb/python_dateutil-2.8.1-py2.py3-none-any.whl
Collecting multidict (from grpclib<0.5.0,>=0.4.1->betterproto<3.0,>=2.0.0b3->onos-api==0.7.24.dev0)
  Using cached https://files.pythonhosted.org/packages/bf/1f/6ccb2f678e6d147cc6eec00a5b8615f9fa8d8a8271cc98a2ffa0343c9063/multidict-5.1.0-cp37-cp37m-macosx_10_14_x86_64.whl
Collecting h2<5,>=3.1.0 (from grpclib<0.5.0,>=0.4.1->betterproto<3.0,>=2.0.0b3->onos-api==0.7.24.dev0)
  Using cached https://files.pythonhosted.org/packages/bd/c2/5ffec707d0022208787908d9657f782ce35b653baa1e87abecf22a7cf513/h2-4.0.0-py3-none-any.whl
Collecting six>=1.5 (from python-dateutil<3.0,>=2.8->betterproto<3.0,>=2.0.0b3->onos-api==0.7.24.dev0)
  Using cached https://files.pythonhosted.org/packages/ee/ff/48bde5c0f013094d729fe4b0316ba2a24774b3ff1c52d924a8a4cb04078a/six-1.15.0-py2.py3-none-any.whl
Collecting hyperframe<7,>=6.0 (from h2<5,>=3.1.0->grpclib<0.5.0,>=0.4.1->betterproto<3.0,>=2.0.0b3->onos-api==0.7.24.dev0)
  Using cached https://files.pythonhosted.org/packages/e7/38/ca89dce3bc19aa5d4d524a66b64ccc40e7bd4e39a80d9791e5e423e1fa1f/hyperframe-6.0.0-py3-none-any.whl
Collecting hpack<5,>=4.0 (from h2<5,>=3.1.0->grpclib<0.5.0,>=0.4.1->betterproto<3.0,>=2.0.0b3->onos-api==0.7.24.dev0)
  Using cached https://files.pythonhosted.org/packages/d5/34/e8b383f35b77c402d28563d2b8f83159319b509bc5f760b15d60b0abf165/hpack-4.0.0-py3-none-any.whl
Installing collected packages: multidict, hyperframe, hpack, h2, grpclib, six, python-dateutil, betterproto, onos-api
  Running setup.py install for onos-api ... done
Successfully installed betterproto-2.0.0b3 grpclib-0.4.1 h2-4.0.0 hpack-4.0.0 hyperframe-6.0.0 multidict-5.1.0 onos-api-0.7.24.dev0 python-dateutil-2.8.1 six-1.15.0
WARNING: You are using pip version 19.2.3, however version 21.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
(my_venv) omikader@omikader-mbp onos-api % python
Python 3.7.5 (default, Oct 22 2019, 10:35:10)
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from onos_api.onos.e2sub.endpoint import E2RegistryServiceStub
>>> dir(E2RegistryServiceStub)
['_ServiceStub__resolve_request_kwargs', '__abstractmethods__', '__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__slots__', '__str__', '__subclasshook__', '__weakref__', '_abc_impl', '_send_messages', '_stream_stream', '_stream_unary', '_unary_stream', '_unary_unary', 'add_termination', 'get_termination', 'list_terminations', 'remove_termination', 'watch_terminations']
```