### PR TITLE
Fix gNMI Python reference

### DIFF
--- a/python/onos/config/admin/__init__.py
+++ b/python/onos/config/admin/__init__.py
@@ -7,6 +7,7 @@ from typing import AsyncIterable, AsyncIterator, Iterable, List, Optional, Union
 
 import betterproto
 import grpclib
+import gnmi.proto
 
 
 class Type(betterproto.Enum):
@@ -104,7 +105,7 @@ class ModelInfo(betterproto.Message):
     # model_data is a set of metadata about the YANG files that went in to
     # generating the model plugin. It includes name, version and organization for
     # each YANG file, similar to how they are represented in gNMI Capabilities.
-    model_data: List["___gnmi__.ModelData"] = betterproto.message_field(3)
+    model_data: List[gnmi.proto.ModelData] = betterproto.message_field(3)
     # module is the name of the Model Plugin on the file system - usually ending
     # in .so.<version>.
     module: str = betterproto.string_field(4)
@@ -353,6 +354,5 @@ class ConfigAdminServiceStub(betterproto.ServiceStub):
         )
 
 
-from .... import gnmi as ___gnmi__
 from ..change import device as _change_device__
 from ..snapshot import device as _snapshot_device__

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     ],
     install_requires=[
         "betterproto>=2.0.0b3,<3",
-        "gnmi-proto",
+        "gnmi-proto>=0.1.0a4,<1",
     ],
     python_requires=">=3.6",
     setup_requires=["setuptools>=41.1.0"],


### PR DESCRIPTION
This PR adds a version constraint to the `gnmi-proto` dependency and fixes an issue where the admin proto bindings were looking for a local implementation of gNMI bindings.

Before
```
>>> from onos_api.config.admin import ModelInfo
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/private/tmp/my_venv/lib/python3.7/site-packages/onos_api/config/admin/__init__.py", line 356, in <module>
    from .... import gnmi as ___gnmi__
ValueError: attempted relative import beyond top-level package
>>>
```

After
```
(my_venv) omikader@omikader-mbp onos-api % python -c "from onos_api.config.admin import ModelInfo"
(my_venv) omikader@omikader-mbp onos-api % echo $?
0
```